### PR TITLE
Add support for hexadecimal number literals [Broken]

### DIFF
--- a/Mond.Tests/Expressions/ValueTests.cs
+++ b/Mond.Tests/Expressions/ValueTests.cs
@@ -23,6 +23,8 @@ namespace Mond.Tests.Expressions
             Assert.True(Script.Run("return 10e+4;") == 10e+4, "exponent sign +");
 
             Assert.True(Script.Run("return 10e-4;") == 10e-4, "exponent sign -");
+
+            Assert.True( Script.Run( "return 0xDEADBEEF;" ) == 0xDEADBEEF, "hex number" );
         }
 
         [Test]

--- a/Mond/Compiler/Lexer.Static.cs
+++ b/Mond/Compiler/Lexer.Static.cs
@@ -9,6 +9,7 @@ namespace Mond.Compiler
     {
         private static OperatorDictionary _operators;
         private static Dictionary<string, TokenType> _keywords;
+        private static char[] _hexChars;
 
         static Lexer()
         {
@@ -87,6 +88,12 @@ namespace Mond.Compiler
                 { "switch", TokenType.Switch },
                 { "case", TokenType.Case },
                 { "default", TokenType.Default },
+            };
+
+            _hexChars = new char[]
+            {
+                'a', 'b', 'c', 'd', 'e', 'f',
+                'A', 'B', 'C', 'D', 'E', 'F',
             };
         }
 

--- a/Mond/Compiler/Parselets/NumberParselet.cs
+++ b/Mond/Compiler/Parselets/NumberParselet.cs
@@ -1,4 +1,5 @@
 ﻿using Mond.Compiler.Expressions;
+using System.Globalization;
 
 namespace Mond.Compiler.Parselets
 {
@@ -6,7 +7,17 @@ namespace Mond.Compiler.Parselets
     {
         public Expression Parse(Parser parser, Token token)
         {
-            var value = double.Parse(token.Contents);
+            double value;
+
+            try
+            {
+                value = (double)long.Parse( token.Contents, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture );
+            }
+            catch
+            {
+                value = double.Parse( token.Contents, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture );
+            }
+
             return new NumberExpression(token, value);
         }
     }


### PR DESCRIPTION
Simple modification to the lexer and the number parselet to allow hex numbers in Mond source code.
