### PR TITLE
Fixed whitespace error in `struct` example.

### DIFF
--- a/Examples/struct.mnd
+++ b/Examples/struct.mnd
@@ -18,7 +18,7 @@ fun struct(...properties) {
 
     return fun (...values) {
         if (values.length() != properties.length()) {
-            error("struct requires " + properties.length() + "values"); 
+            error("struct requires " + properties.length() + " values"); 
         }
         
         var value = {};


### PR DESCRIPTION
``` csharp
var Point = struct("x", "y", "foo");

var p1 = Point(1, 2);
```

> struct requires 3values

Fix:

> struct requires 3 values 
