### PR TITLE
Fix addition operator not respecting metamethods.

### DIFF
--- a/Mond/MondValue.Operators.cs
+++ b/Mond/MondValue.Operators.cs
@@ -94,9 +94,6 @@ namespace Mond
 
         public static MondValue operator +(MondValue left, MondValue right)
         {
-            if (left.Type == MondValueType.String || right.Type == MondValueType.String)
-                return new MondValue(left.ToString() + right.ToString());
-
             if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
                 return new MondValue(left._numberValue + right._numberValue);
 
@@ -108,6 +105,9 @@ namespace Mond
 
                 return new MondValue((double)left + (double)right);
             }
+            
+            if (left.Type == MondValueType.String || right.Type == MondValueType.String)
+                return new MondValue(left.ToString() + right.ToString());
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "addition", left.Type.GetName(), right.Type.GetName());
         }

--- a/Mond/MondValue.Operators.cs
+++ b/Mond/MondValue.Operators.cs
@@ -97,6 +97,18 @@ namespace Mond
             if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
                 return new MondValue(left._numberValue + right._numberValue);
 
+            if (left.Type == MondValueType.String || right.Type == MondValueType.String)
+            {
+                MondValue result;
+                if (left.TryDispatch("__add", out result, left, right))
+                    return result;
+
+                if (right.TryDispatch("__add", out result, right, right))
+                    return result;
+
+                return new MondValue(left.ToString() + right.ToString());
+            }
+
             if (left.Type == MondValueType.Object || right.Type == MondValueType.Object)
             {
                 MondValue result;
@@ -105,9 +117,6 @@ namespace Mond
 
                 return new MondValue((double)left + (double)right);
             }
-            
-            if (left.Type == MondValueType.String || right.Type == MondValueType.String)
-                return new MondValue(left.ToString() + right.ToString());
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "addition", left.Type.GetName(), right.Type.GetName());
         }


### PR DESCRIPTION
The current implementation of the addition operator overload for `MondValue` would simply coerce both the left- and right-hand sides to string if one of them was a string, this has the side of effect of completely ignoring any objects that define the `__add` metamethod and producing unexpected results.

**Side note**: I feel the aggressive coercion of the addition operator overload should be reigned in. Perhaps only allowing strings to be concatenated with other strings, numbers, or boolean and throwing an exception for arrays, objects, and functions.

**Edit**: just realized unit tests are broken, fixing now.