### PR TITLE
Implementing user-defined-operators

### DIFF
--- a/Mond.Tests/Binding/OperatorTests.cs
+++ b/Mond.Tests/Binding/OperatorTests.cs
@@ -27,12 +27,12 @@ namespace Mond.Tests.Binding
             }
 
             [MondOperator("%%")]
-            public static double RandomNumber(MondValue range)
+            public static double SumOrDouble(MondState state, MondValue range)
             {
-                if(range.Type == MondValueType.Number)
-                    return _rng.Next(0, (int)range);
+                if (range.Type == MondValueType.Number)
+                    return range * 2d;
 
-                return _rng.Next((int)range["begin"], (int)range["end"] + (range["inclusive"] ? 1 : 0));
+                return range.Enumerate(state).Sum(n => (double)n);
             }
 
             private static MondValue CreateGenerator(double begin, double end, bool inclusive)
@@ -72,7 +72,7 @@ namespace Mond.Tests.Binding
         {
             var result = _state.Run("return %% 5;");
 
-            Assert.True(NumberBetween(result, 0, 5));
+            Assert.True(result == 10);
         }
 
         [Test]
@@ -100,13 +100,8 @@ namespace Mond.Tests.Binding
                     b: %%(6 <...> 10)
                 };");
 
-            Assert.True(NumberBetween(result["a"], 0, 5));
-            Assert.True(NumberBetween(result["b"], 6, 9));
-        }
-
-        private static bool NumberBetween(double n, double lo, double hi)
-        {
-            return n >= lo && n <= hi;
+            Assert.True(result["a"] == 16);
+            Assert.True(result["b"] == 30);
         }
     }
 }

--- a/Mond.Tests/Binding/OperatorTests.cs
+++ b/Mond.Tests/Binding/OperatorTests.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mond.Binding;
+using NUnit.Framework;
+
+namespace Mond.Tests.Binding
+{
+    [TestFixture]
+    public class OperatorTests
+    {
+        [MondOperatorModule]
+        class MyOperators
+        {
+            private static Random _rng = new Random();
+
+            [MondOperator("<..>")]
+            public static MondValue InclusiveRange(double begin, double end)
+            {
+                return CreateGenerator(begin, end, true);
+            }
+
+            [MondOperator("<...>")]
+            public static MondValue ExclusiveRange(double begin, double end)
+            {
+                return CreateGenerator(begin, end, false);
+            }
+
+            [MondOperator("%%")]
+            public static double RandomNumber(MondValue range)
+            {
+                if(range.Type == MondValueType.Number)
+                    return _rng.Next(0, (int)range);
+
+                return _rng.Next((int)range["begin"], (int)range["end"] + (range["inclusive"] ? 1 : 0));
+            }
+
+            private static MondValue CreateGenerator(double begin, double end, bool inclusive)
+            {
+                var actualBegin = Math.Min(begin, end);
+                var actualEnd = Math.Max(begin, end);
+                var range = MondValue.FromEnumerable(Generate(actualBegin, actualEnd, inclusive));
+                range["begin"] = begin;
+                range["end"] = end;
+                range["inclusive"] = inclusive;
+
+                return range;
+            }
+
+            private static IEnumerable<MondValue> Generate(double begin, double end, bool inclusive)
+            {
+                var i = begin;
+                for(; i < end; ++i)
+                    yield return i;
+
+                if(inclusive)
+                    yield return ++i;
+            }
+        }
+
+        private MondState _state;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _state = new MondState();
+            MondOperatorModuleBinder.Bind<MyOperators>(_state);
+        }
+
+        [Test]
+        public void Unary()
+        {
+            var result = _state.Run("return %% 5;");
+
+            Assert.True(NumberBetween(result, 0, 5));
+        }
+
+        [Test]
+        public void Binary()
+        {
+            var result = _state.Run(@"
+                return {
+                    a: 0 <..> 5,
+                    b: 6 <...> 10
+                };");
+
+            var a = result["a"];
+            var b = result["b"];
+
+            Assert.True(a["inclusive"] == true && a["begin"] == 0 && a["end"] == 5);
+            Assert.True(b["inclusive"] == false && b["begin"] == 6 && b["end"] == 10);
+        }
+        
+        [Test]
+        public void Mixed()
+        {
+            var result = _state.Run(@"
+                return {
+                    a: %%(0 <..> 5),
+                    b: %%(6 <...> 10)
+                };");
+
+            Assert.True(NumberBetween(result["a"], 0, 5));
+            Assert.True(NumberBetween(result["b"], 6, 9));
+        }
+
+        private static bool NumberBetween(double n, double lo, double hi)
+        {
+            return n >= lo && n <= hi;
+        }
+    }
+}

--- a/Mond.Tests/Expressions/FunctionTests.cs
+++ b/Mond.Tests/Expressions/FunctionTests.cs
@@ -285,5 +285,53 @@ namespace Mond.Tests.Expressions
 
             Assert.True(result == 2);
         }
+
+        [Test]
+        public void UnaryUserDefinedOperator()
+        {
+            var state = Script.Load(@"
+                seq (%%)(n) {
+                    if (n == 0) {
+                        yield 0;
+                        return;
+                    }
+
+                    var a = 1;
+                    var b = 1;
+
+                    for (var i = 3; i <= n; i++) {
+                        var c = a + b;
+                        a = b;
+                        b = c;
+
+                        yield b;
+                    }
+                }
+
+                global.test = %% 10;
+            ");
+
+            var expected = new[] { 2, 3, 5, 8, 13, 21, 34, 55 }.Select(n => new MondValue(n));
+            Assert.True(state["test"].Enumerate(state).SequenceEqual(expected));
+        }
+
+        [Test]
+        public void BinaryUserDefinedOperator()
+        {
+            var result = Script.Run(@"
+                fun (>>>)(fun1, fun2) {
+                    return fun(... args) {
+                        return fun1(... args) |> fun2();
+                    };
+                }
+
+                fun double(n) -> n *  2;
+                fun square(n) -> n ** 2;
+
+                return (square >>> double)(5);
+            ");
+
+            Assert.True(result == 50);
+        }
     }
 }

--- a/Mond.Tests/Mond.Tests.csproj
+++ b/Mond.Tests/Mond.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Binding\FunctionOverloadingTests.cs" />
     <Compile Include="Binding\FunctionTests.cs" />
     <Compile Include="Binding\ModuleTests.cs" />
+    <Compile Include="Binding\OperatorTests.cs" />
     <Compile Include="Expressions\ArrayTests.cs" />
     <Compile Include="Expressions\ExpressionTests.cs" />
     <Compile Include="Expressions\FunctionTests.cs" />

--- a/Mond/Binding/BindingError.cs
+++ b/Mond/Binding/BindingError.cs
@@ -14,6 +14,8 @@ namespace Mond.Binding
 
         public const string DuplicateDefinition = "Duplicate definition of '{0}'";
 
+        public const string NameIsntValidOperator = "'{0}' is not a valid operator name";
+
         public static string MethodsHiddenError(IEnumerable<MethodBase> methods)
         {
             var sb = new StringBuilder();

--- a/Mond/Binding/MondFunctionBinder.Shared.cs
+++ b/Mond/Binding/MondFunctionBinder.Shared.cs
@@ -11,7 +11,7 @@ namespace Mond.Binding
 
         internal enum MethodType
         {
-            Normal, Property, Constructor
+            Normal, Property, Constructor, Operator
         }
 
         internal static List<MethodTable> BuildMethodTables(IEnumerable<MethodBase> source, MethodType methodType, string nameOverride = null)
@@ -21,10 +21,9 @@ namespace Mond.Binding
                 case MethodType.Normal:
                     {
                         return source
-                            .Select(m => new { Method = m, FunctionAttribute = m.Attribute<MondFunctionAttribute>(), OperatorAttribute = m.Attribute<MondOperatorAttribute>() })
-                            .Where(m => m.FunctionAttribute != null || m.OperatorAttribute != null)
-                            .GroupBy(m => nameOverride ?? (m.FunctionAttribute == null ? null : m.FunctionAttribute.Name) ??
-                                         (m.OperatorAttribute == null ? null : m.OperatorAttribute.Operator) ?? m.Method.Name)
+                            .Select(m => new { Method = m, FunctionAttribute = m.Attribute<MondFunctionAttribute>() })
+                            .Where(m => m.FunctionAttribute != null)
+                            .GroupBy(m => nameOverride ?? m.FunctionAttribute.Name ?? m.Method.Name)
                             .Select(g => BuildMethodTable(g.Select(m => new Method(g.Key, m.Method))))
                             .ToList();
                     }
@@ -50,6 +49,16 @@ namespace Mond.Binding
                         {
                             BuildMethodTable(methods.Select(m => new Method("#ctor", m)))
                         };
+                    }
+
+                case MethodType.Operator:
+                    {
+                        return source
+                            .Select(m => new { Method = m, OperatorAttribute = m.Attribute<MondOperatorAttribute>() })
+                            .Where(m => m.OperatorAttribute != null)
+                            .GroupBy(m => m.OperatorAttribute.Operator)
+                            .Select(g => BuildMethodTable(g.Select(m => new Method(g.Key, m.Method))))
+                            .ToList();
                     }
 
                 default:

--- a/Mond/Binding/MondFunctionBinder.Shared.cs
+++ b/Mond/Binding/MondFunctionBinder.Shared.cs
@@ -21,9 +21,10 @@ namespace Mond.Binding
                 case MethodType.Normal:
                     {
                         return source
-                            .Select(m => new { Method = m, FunctionAttribute = m.Attribute<MondFunctionAttribute>() })
-                            .Where(m => m.FunctionAttribute != null)
-                            .GroupBy(m => nameOverride ?? m.FunctionAttribute.Name ?? m.Method.Name)
+                            .Select(m => new { Method = m, FunctionAttribute = m.Attribute<MondFunctionAttribute>(), OperatorAttribute = m.Attribute<MondOperatorAttribute>() })
+                            .Where(m => m.FunctionAttribute != null || m.OperatorAttribute != null)
+                            .GroupBy(m => nameOverride ?? (m.FunctionAttribute == null ? null : m.FunctionAttribute.Name) ??
+                                         (m.OperatorAttribute == null ? null : m.OperatorAttribute.Operator) ?? m.Method.Name)
                             .Select(g => BuildMethodTable(g.Select(m => new Method(g.Key, m.Method))))
                             .ToList();
                     }

--- a/Mond/Binding/MondOperatorAttribute.cs
+++ b/Mond/Binding/MondOperatorAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Mond.Binding
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class MondOperatorAttribute : Attribute
+    {
+        public string Operator { get; private set; }
+
+        public MondOperatorAttribute(string @operator)
+        {
+            if (string.IsNullOrWhiteSpace(@operator))
+                throw new ArgumentNullException("@operator");
+
+            Operator = @operator;
+        }
+    }
+}

--- a/Mond/Binding/MondOperatorAttribute.cs
+++ b/Mond/Binding/MondOperatorAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Mond.Compiler;
 
 namespace Mond.Binding
 {
@@ -9,8 +10,11 @@ namespace Mond.Binding
 
         public MondOperatorAttribute(string @operator)
         {
-            if (string.IsNullOrWhiteSpace(@operator))
-                throw new ArgumentNullException("@operator");
+            if (!Lexer.IsOperatorToken(@operator))
+                throw new MondBindingException(BindingError.NameIsntValidOperator, @operator);
+
+            if (Lexer.OperatorExists(@operator))
+                throw new MondBindingException(CompilerError.CantOverrideBuiltInOperator, @operator);
 
             Operator = @operator;
         }

--- a/Mond/Binding/MondOperatorModuleAttribute.cs
+++ b/Mond/Binding/MondOperatorModuleAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Mond.Binding
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class MondOperatorModuleAttribute : Attribute
+    {
+   
+    }
+}

--- a/Mond/Binding/MondOperatorModuleBinder.cs
+++ b/Mond/Binding/MondOperatorModuleBinder.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Mond.Binding
+{
+    public static class MondOperatorModuleBinder
+    {
+        private static HashSet<Type> _cache = new HashSet<Type>();
+
+        public static void Bind<T>(MondState state)
+        {
+            Bind(typeof(T), state);
+        }
+
+        public static void Bind(Type type, MondState state)
+        {
+            if (state == null)
+                throw new ArgumentNullException("state");
+
+            lock (_cache)
+            {
+                if (!_cache.Add(type))
+                    return;
+            }
+
+            var operatorModuleAttr = type.Attribute<MondOperatorModuleAttribute>();
+
+            if (operatorModuleAttr == null)
+                throw new MondBindingException(BindingError.TypeMissingAttribute, "MondOperatorModule");
+
+            var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Static);
+            var boundMethods = MondFunctionBinder.BindStatic(type.Name, methods);
+            var opsObject = state["__ops"];
+
+            foreach (var method in boundMethods)
+                opsObject[method.Item1] = method.Item2;
+        }
+    }
+}

--- a/Mond/Compiler/CompilerError.cs
+++ b/Mond/Compiler/CompilerError.cs
@@ -15,6 +15,8 @@
 
         public const string IncorrectOperatorArity = "Incorrect operator arity ({0}). User defined operators may only accept 1 (prefix) or 2 (infix) arguments";
         public const string EllipsisInOperator = "User defined operators may not have ellipsis arguments";
+        public const string CantNestOperatorDecl = "User defined operators may only be declared in the top-level scope";
+        public const string CantOverrideBuiltInOperator = "Cannot define operator '{0}', as it would shadow the built-in '{0}' operator";
 
         public const string UndefinedIdentifier = "Undefined identifier '{0}'";
         public const string IdentifierAlreadyDefined = "Identifier '{0}' was previously defined in this scope";

--- a/Mond/Compiler/CompilerError.cs
+++ b/Mond/Compiler/CompilerError.cs
@@ -13,6 +13,9 @@
         public const string ExpectedButFound2 = "Expected {0} or {1} but found {2}";
         public const string CrMustBeFollowedByLf = "\\r must be followed by \\n";
 
+        public const string IncorrectOperatorArity = "Incorrect operator arity ({0}). User defined operators may only accept 1 (prefix) or 2 (infix) arguments";
+        public const string EllipsisInOperator = "User defined operators may not have ellipsis arguments";
+
         public const string UndefinedIdentifier = "Undefined identifier '{0}'";
         public const string IdentifierAlreadyDefined = "Identifier '{0}' was previously defined in this scope";
         public const string CantModifyReadonlyVar = "Cannot modify '{0}' because it is readonly";

--- a/Mond/Compiler/Expressions/Statements/FunctionExpression.cs
+++ b/Mond/Compiler/Expressions/Statements/FunctionExpression.cs
@@ -8,18 +8,20 @@ namespace Mond.Compiler.Expressions.Statements
         public string Name { get; private set; }
         public ReadOnlyCollection<string> Arguments { get; private set; }
         public string OtherArguments { get; private set; }
+        public bool IsOperator { get; private set; }
         public ScopeExpression Block { get; private set; }
 
         public string DebugName { get; set; }
 
         public bool HasChildren { get { return false; } }
 
-        public FunctionExpression(Token token, string name, List<string> arguments, string otherArgs, ScopeExpression block, string debugName = null)
+        public FunctionExpression(Token token, string name, List<string> arguments, string otherArgs, bool isOperator, ScopeExpression block, string debugName = null)
             : base(token)
         {
             Name = name;
             Arguments = arguments.AsReadOnly();
             OtherArguments = otherArgs;
+            IsOperator = isOperator;
             Block = block;
 
             DebugName = debugName;
@@ -44,9 +46,12 @@ namespace Mond.Compiler.Expressions.Statements
 
         public override int Compile(FunctionContext context)
         {
+            if (IsOperator && !(Parent is BinaryOperatorExpression && Parent.Parent is BlockExpression && !(Parent.Parent is ScopeExpression)))
+                throw new MondCompilerException(Token, CompilerError.CantNestOperatorDecl);
+
             var isStatement = Parent is IBlockExpression;
             var shouldBeGlobal = context.ArgIndex == 0 && context.Compiler.Options.MakeRootDeclarationsGlobal;
-            var shouldStore = Name != null;
+            var shouldStore = Name != null && !IsOperator;
 
             IdentifierOperand identifier = null;
 

--- a/Mond/Compiler/Expressions/Statements/FunctionExpression.cs
+++ b/Mond/Compiler/Expressions/Statements/FunctionExpression.cs
@@ -46,7 +46,7 @@ namespace Mond.Compiler.Expressions.Statements
 
         public override int Compile(FunctionContext context)
         {
-            if (IsOperator && !(Parent is BinaryOperatorExpression && Parent.Parent is BlockExpression && !(Parent.Parent is ScopeExpression)))
+            if (IsOperator && Lexer.IsOperatorToken(Name) && !(Parent is BinaryOperatorExpression && Parent.Parent is BlockExpression && !(Parent.Parent is ScopeExpression)))
                 throw new MondCompilerException(Token, CompilerError.CantNestOperatorDecl);
 
             var isStatement = Parent is IBlockExpression;

--- a/Mond/Compiler/Expressions/Statements/SequenceExpression.cs
+++ b/Mond/Compiler/Expressions/Statements/SequenceExpression.cs
@@ -4,8 +4,8 @@ namespace Mond.Compiler.Expressions.Statements
 {
     class SequenceExpression : FunctionExpression
     {
-        public SequenceExpression(Token token, string name, List<string> arguments, string otherArgs, ScopeExpression block, string debugName = null)
-            : base(token, name, arguments, otherArgs, block, debugName)
+        public SequenceExpression(Token token, string name, List<string> arguments, string otherArgs, bool isOperator, ScopeExpression block, string debugName = null)
+            : base(token, name, arguments, otherArgs, isOperator, block, debugName)
         {
 
         }
@@ -17,7 +17,7 @@ namespace Mond.Compiler.Expressions.Statements
 
             var stack = 0;
             var bodyToken = new Token(Token, TokenType.Fun, null);
-            var body = new SequenceBodyExpression(bodyToken, null, Block, "moveNext", state, enumerable);
+            var body = new SequenceBodyExpression(bodyToken, null, IsOperator, Block, "moveNext", state, enumerable);
             var seqContext = new SequenceContext(context.Compiler, "moveNext", body, context);
 
             var getEnumerator = context.MakeFunction("getEnumerator");
@@ -89,9 +89,9 @@ namespace Mond.Compiler.Expressions.Statements
         public int NextState { get { return _stateLabels.Count; } }
         public LabelOperand EndLabel { get; private set; }
 
-        public SequenceBodyExpression(Token token, string name, ScopeExpression block, string debugName,
+        public SequenceBodyExpression(Token token, string name, bool isOperator, ScopeExpression block, string debugName,
                                       IdentifierOperand state, IdentifierOperand enumerable)
-            : base(token, name, new List<string> { "#input" }, null, block, debugName)
+            : base(token, name, new List<string> { "#input" }, null, isOperator, block, debugName)
         {
             _stateLabels = new List<LabelOperand>();
 

--- a/Mond/Compiler/Expressions/UserDefinedBinaryOperatorExpression.cs
+++ b/Mond/Compiler/Expressions/UserDefinedBinaryOperatorExpression.cs
@@ -5,16 +5,15 @@ namespace Mond.Compiler.Expressions
 {
     class UserDefinedBinaryOperatorExpression : Expression
     {
-        public string Operator { get; private set; }
+        public string Operator { get { return Token.Contents; } }
         public Expression Left { get; private set; }
         public Expression Right { get; private set; }
 
-        public UserDefinedBinaryOperatorExpression(Token token, Expression left, Expression right, string @operator)
+        public UserDefinedBinaryOperatorExpression(Token token, Expression left, Expression right)
             : base(token)
         {
             Left = left;
             Right = right;
-            Operator = @operator;
         }
 
         public override int Compile(FunctionContext context)

--- a/Mond/Compiler/Expressions/UserDefinedBinaryOperatorExpression.cs
+++ b/Mond/Compiler/Expressions/UserDefinedBinaryOperatorExpression.cs
@@ -22,6 +22,7 @@ namespace Mond.Compiler.Expressions
 
             stack += Left.Compile(context);
             stack += Right.Compile(context);
+            context.Position(Token); // debug info
             stack += context.LoadGlobal();
             stack += context.LoadField(context.String("__ops"));
             stack += context.LoadField(context.String(Operator));

--- a/Mond/Compiler/Expressions/UserDefinedBinaryOperatorExpression.cs
+++ b/Mond/Compiler/Expressions/UserDefinedBinaryOperatorExpression.cs
@@ -24,7 +24,7 @@ namespace Mond.Compiler.Expressions
             stack += Left.Compile(context);
             stack += Right.Compile(context);
             stack += context.LoadGlobal();
-            stack += context.LoadField(context.String("$ops"));
+            stack += context.LoadField(context.String("__ops"));
             stack += context.LoadField(context.String(Operator));
             stack += context.Call(2, new List<ImmediateOperand>());
 

--- a/Mond/Compiler/Expressions/UserDefinedBinaryOperatorExpression.cs
+++ b/Mond/Compiler/Expressions/UserDefinedBinaryOperatorExpression.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Mond.Compiler.Expressions
+{
+    class UserDefinedBinaryOperatorExpression : Expression
+    {
+        public string Operator { get; private set; }
+        public Expression Left { get; private set; }
+        public Expression Right { get; private set; }
+
+        public UserDefinedBinaryOperatorExpression(Token token, Expression left, Expression right, string @operator)
+            : base(token)
+        {
+            Left = left;
+            Right = right;
+            Operator = @operator;
+        }
+
+        public override int Compile(FunctionContext context)
+        {
+            var stack = 0;
+
+            stack += Left.Compile(context);
+            stack += Right.Compile(context);
+            stack += context.LoadGlobal();
+            stack += context.LoadField(context.String("$ops"));
+            stack += context.LoadField(context.String(Operator));
+            stack += context.Call(2, new List<ImmediateOperand>());
+
+            CheckStack(stack, 1);
+            return stack;
+        }
+
+        public override Expression Simplify()
+        {
+            Left = Left.Simplify();
+            Right = Right.Simplify();
+
+            return this;
+        }
+
+        public override T Accept<T>(IExpressionVisitor<T> visitor)
+        {
+            return visitor.Visit(this);
+        }
+    }
+}

--- a/Mond/Compiler/Expressions/UserDefinedUnaryOperator.cs
+++ b/Mond/Compiler/Expressions/UserDefinedUnaryOperator.cs
@@ -5,14 +5,13 @@ namespace Mond.Compiler.Expressions
 {
     class UserDefinedUnaryOperator : Expression
     {
-        public string Operator { get; private set; }
+        public string Operator { get { return Token.Contents; } }
         public Expression Right { get; private set; }
 
-        public UserDefinedUnaryOperator(Token token, Expression right, string @operator)
+        public UserDefinedUnaryOperator(Token token, Expression right)
             : base(token)
         {
             Right = right;
-            Operator = @operator;
         }
 
         public override int Compile(FunctionContext context)

--- a/Mond/Compiler/Expressions/UserDefinedUnaryOperator.cs
+++ b/Mond/Compiler/Expressions/UserDefinedUnaryOperator.cs
@@ -21,7 +21,7 @@ namespace Mond.Compiler.Expressions
 
             stack += Right.Compile(context);
             stack += context.LoadGlobal();
-            stack += context.LoadField(context.String("$ops"));
+            stack += context.LoadField(context.String("__ops"));
             stack += context.LoadField(context.String(Operator));
             stack += context.Call(1, new List<ImmediateOperand>());
 

--- a/Mond/Compiler/Expressions/UserDefinedUnaryOperator.cs
+++ b/Mond/Compiler/Expressions/UserDefinedUnaryOperator.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Mond.Compiler.Expressions
+{
+    class UserDefinedUnaryOperator : Expression
+    {
+        public string Operator { get; private set; }
+        public Expression Right { get; private set; }
+
+        public UserDefinedUnaryOperator(Token token, Expression right, string @operator)
+            : base(token)
+        {
+            Right = right;
+            Operator = @operator;
+        }
+
+        public override int Compile(FunctionContext context)
+        {
+            var stack = 0;
+
+            stack += Right.Compile(context);
+            stack += context.LoadGlobal();
+            stack += context.LoadField(context.String("$ops"));
+            stack += context.LoadField(context.String(Operator));
+            stack += context.Call(1, new List<ImmediateOperand>());
+
+            CheckStack(stack, 1);
+            return stack;
+        }
+
+        public override Expression Simplify()
+        {
+            Right = Right.Simplify();
+
+            return this;
+        }
+
+        public override T Accept<T>(IExpressionVisitor<T> visitor)
+        {
+            return visitor.Visit(this);
+        }
+    }
+}

--- a/Mond/Compiler/Expressions/UserDefinedUnaryOperator.cs
+++ b/Mond/Compiler/Expressions/UserDefinedUnaryOperator.cs
@@ -19,6 +19,7 @@ namespace Mond.Compiler.Expressions
             var stack = 0;
 
             stack += Right.Compile(context);
+            context.Position(Token); // debug info
             stack += context.LoadGlobal();
             stack += context.LoadField(context.String("__ops"));
             stack += context.LoadField(context.String(Operator));

--- a/Mond/Compiler/Lexer.Static.cs
+++ b/Mond/Compiler/Lexer.Static.cs
@@ -67,8 +67,8 @@ namespace Mond.Compiler
                 { "||", TokenType.ConditionalOr, TokenSubType.Operator },
 
                 { "?", TokenType.QuestionMark, TokenSubType.Operator },
-                { ":", TokenType.Colon, TokenSubType.Operator },
-                { "->", TokenType.Pointy, TokenSubType.Operator },
+                { ":", TokenType.Colon, TokenSubType.Punctuation },
+                { "->", TokenType.Pointy, TokenSubType.Punctuation },
                 { "|>", TokenType.Pipeline, TokenSubType.Operator },
                 { "...", TokenType.Ellipsis, TokenSubType.Operator },
                 { "!in", TokenType.NotIn, TokenSubType.Punctuation }

--- a/Mond/Compiler/Lexer.Static.cs
+++ b/Mond/Compiler/Lexer.Static.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -14,19 +15,19 @@ namespace Mond.Compiler
         {
             _operators = new OperatorDictionary
             {
-                { ";", TokenType.Semicolon, TokenSubType.None },
-                { ",", TokenType.Comma, TokenSubType.None },
+                { ";", TokenType.Semicolon, TokenSubType.Punctuation },
+                { ",", TokenType.Comma, TokenSubType.Punctuation },
                 { ".", TokenType.Dot, TokenSubType.Operator },
                 { "=", TokenType.Assign, TokenSubType.Operator },
 
-                { "(", TokenType.LeftParen, TokenSubType.None },
-                { ")", TokenType.RightParen, TokenSubType.None },
+                { "(", TokenType.LeftParen, TokenSubType.Punctuation },
+                { ")", TokenType.RightParen, TokenSubType.Punctuation },
 
-                { "{", TokenType.LeftBrace, TokenSubType.None },
-                { "}", TokenType.RightBrace, TokenSubType.None },
+                { "{", TokenType.LeftBrace, TokenSubType.Punctuation },
+                { "}", TokenType.RightBrace, TokenSubType.Punctuation },
 
-                { "[", TokenType.LeftSquare, TokenSubType.None },
-                { "]", TokenType.RightSquare, TokenSubType.None },
+                { "[", TokenType.LeftSquare, TokenSubType.Punctuation },
+                { "]", TokenType.RightSquare, TokenSubType.Punctuation },
 
                 { "+", TokenType.Add, TokenSubType.Operator },
                 { "-", TokenType.Subtract, TokenSubType.Operator },
@@ -70,7 +71,7 @@ namespace Mond.Compiler
                 { "->", TokenType.Pointy, TokenSubType.Operator },
                 { "|>", TokenType.Pipeline, TokenSubType.Operator },
                 { "...", TokenType.Ellipsis, TokenSubType.Operator },
-                { "!in", TokenType.NotIn, TokenSubType.None }
+                { "!in", TokenType.NotIn, TokenSubType.Punctuation }
             };
 
             _keywords = new Dictionary<string, TokenType>
@@ -112,7 +113,17 @@ namespace Mond.Compiler
             };
         }
 
-        class OperatorDictionary : IEnumerable<object>
+        public static bool OperatorExists(string @operator)
+        {
+            return _operators.Where(kvp => kvp.Value.Where(tup => tup.Item1 == @operator && tup.Item3 == TokenSubType.Operator).Any()).Any();
+        }
+
+        public static bool OperatorExists(TokenType type)
+        {
+            return _operators.Where(kvp => kvp.Value.Where(tup => tup.Item2 == type && tup.Item3 == TokenSubType.Operator).Any()).Any();
+        }
+
+        class OperatorDictionary : IEnumerable<KeyValuePair<char, List<Tuple<string, TokenType, TokenSubType>>>>
         {
             private readonly GenericComparer<Tuple<string, TokenType, TokenSubType>> _comparer; 
             private Dictionary<char, List<Tuple<string, TokenType, TokenSubType>>> _operatorDictionary;
@@ -145,9 +156,14 @@ namespace Mond.Compiler
                 return list;
             }
 
-            public IEnumerator<object> GetEnumerator()
+            public IEnumerator<KeyValuePair<char, List<Tuple<string, TokenType, TokenSubType>>>> GetEnumerator()
             {
-                throw new NotSupportedException();
+                var enumerator = _operatorDictionary.GetEnumerator();
+
+                while (enumerator.MoveNext())
+                    yield return enumerator.Current;
+
+                enumerator.Dispose();
             }
 
             IEnumerator IEnumerable.GetEnumerator()

--- a/Mond/Compiler/Lexer.Static.cs
+++ b/Mond/Compiler/Lexer.Static.cs
@@ -127,6 +127,16 @@ namespace Mond.Compiler
             };
         }
 
+        public static bool IsOperatorToken(string s)
+        {
+            return !string.IsNullOrWhiteSpace(s) && s.All(_operatorChars.Contains);
+        }
+
+        public static bool OperatorExists(string s)
+        {
+            return IsOperatorToken(s) && _operators.ContainsKey(s);
+        }
+
         class OperatorDictionary : IEnumerable<KeyValuePair<char, List<Tuple<string, TokenType, TokenSubType>>>>
         {
             private readonly GenericComparer<Tuple<string, TokenType, TokenSubType>> _comparer; 

--- a/Mond/Compiler/Lexer.Static.cs
+++ b/Mond/Compiler/Lexer.Static.cs
@@ -127,16 +127,6 @@ namespace Mond.Compiler
             };
         }
 
-        public static bool OperatorExists(string @operator)
-        {
-            return _punctuation.Where(kvp => kvp.Value.Where(tup => tup.Item1 == @operator && tup.Item3 == TokenSubType.Operator).Any()).Any();
-        }
-
-        public static bool OperatorExists(TokenType type)
-        {
-            return _punctuation.Where(kvp => kvp.Value.Where(tup => tup.Item2 == type && tup.Item3 == TokenSubType.Operator).Any()).Any();
-        }
-
         class OperatorDictionary : IEnumerable<KeyValuePair<char, List<Tuple<string, TokenType, TokenSubType>>>>
         {
             private readonly GenericComparer<Tuple<string, TokenType, TokenSubType>> _comparer; 

--- a/Mond/Compiler/Lexer.Static.cs
+++ b/Mond/Compiler/Lexer.Static.cs
@@ -14,63 +14,63 @@ namespace Mond.Compiler
         {
             _operators = new OperatorDictionary
             {
-                { ";", TokenType.Semicolon },
-                { ",", TokenType.Comma },
-                { ".", TokenType.Dot },
-                { "=", TokenType.Assign },
+                { ";", TokenType.Semicolon, TokenSubType.None },
+                { ",", TokenType.Comma, TokenSubType.None },
+                { ".", TokenType.Dot, TokenSubType.Operator },
+                { "=", TokenType.Assign, TokenSubType.Operator },
 
-                { "(", TokenType.LeftParen },
-                { ")", TokenType.RightParen },
+                { "(", TokenType.LeftParen, TokenSubType.None },
+                { ")", TokenType.RightParen, TokenSubType.None },
 
-                { "{", TokenType.LeftBrace },
-                { "}", TokenType.RightBrace },
+                { "{", TokenType.LeftBrace, TokenSubType.None },
+                { "}", TokenType.RightBrace, TokenSubType.None },
 
-                { "[", TokenType.LeftSquare },
-                { "]", TokenType.RightSquare },
+                { "[", TokenType.LeftSquare, TokenSubType.None },
+                { "]", TokenType.RightSquare, TokenSubType.None },
 
-                { "+", TokenType.Add },
-                { "-", TokenType.Subtract },
-                { "*", TokenType.Multiply },
-                { "/", TokenType.Divide },
-                { "%", TokenType.Modulo },
-                { "**", TokenType.Exponent },
-                { "&", TokenType.BitAnd },
-                { "|", TokenType.BitOr },
-                { "^", TokenType.BitXor },
-                { "~", TokenType.BitNot },
-                { "<<", TokenType.BitLeftShift },
-                { ">>", TokenType.BitRightShift },
-                { "++", TokenType.Increment },
-                { "--", TokenType.Decrement },
+                { "+", TokenType.Add, TokenSubType.Operator },
+                { "-", TokenType.Subtract, TokenSubType.Operator },
+                { "*", TokenType.Multiply, TokenSubType.Operator },
+                { "/", TokenType.Divide, TokenSubType.Operator },
+                { "%", TokenType.Modulo, TokenSubType.Operator },
+                { "**", TokenType.Exponent, TokenSubType.Operator },
+                { "&", TokenType.BitAnd, TokenSubType.Operator },
+                { "|", TokenType.BitOr, TokenSubType.Operator },
+                { "^", TokenType.BitXor, TokenSubType.Operator },
+                { "~", TokenType.BitNot, TokenSubType.Operator },
+                { "<<", TokenType.BitLeftShift, TokenSubType.Operator },
+                { ">>", TokenType.BitRightShift, TokenSubType.Operator },
+                { "++", TokenType.Increment, TokenSubType.Operator },
+                { "--", TokenType.Decrement, TokenSubType.Operator },
 
-                { "+=", TokenType.AddAssign },
-                { "-=", TokenType.SubtractAssign },
-                { "*=", TokenType.MultiplyAssign },
-                { "/=", TokenType.DivideAssign },
-                { "%=", TokenType.ModuloAssign },
-                { "**=", TokenType.ExponentAssign },
-                { "&=", TokenType.BitAndAssign },
-                { "|=", TokenType.BitOrAssign },
-                { "^=", TokenType.BitXorAssign },
-                { "<<=", TokenType.BitLeftShiftAssign },
-                { ">>=", TokenType.BitRightShiftAssign },
+                { "+=", TokenType.AddAssign, TokenSubType.Operator },
+                { "-=", TokenType.SubtractAssign, TokenSubType.Operator },
+                { "*=", TokenType.MultiplyAssign, TokenSubType.Operator },
+                { "/=", TokenType.DivideAssign, TokenSubType.Operator },
+                { "%=", TokenType.ModuloAssign, TokenSubType.Operator },
+                { "**=", TokenType.ExponentAssign, TokenSubType.Operator },
+                { "&=", TokenType.BitAndAssign, TokenSubType.Operator },
+                { "|=", TokenType.BitOrAssign, TokenSubType.Operator },
+                { "^=", TokenType.BitXorAssign, TokenSubType.Operator },
+                { "<<=", TokenType.BitLeftShiftAssign, TokenSubType.Operator },
+                { ">>=", TokenType.BitRightShiftAssign, TokenSubType.Operator },
                 
-                { "==", TokenType.EqualTo },
-                { "!=", TokenType.NotEqualTo },
-                { ">", TokenType.GreaterThan },
-                { ">=", TokenType.GreaterThanOrEqual },
-                { "<", TokenType.LessThan },
-                { "<=", TokenType.LessThanOrEqual },
-                { "!", TokenType.Not },
-                { "&&", TokenType.ConditionalAnd },
-                { "||", TokenType.ConditionalOr },
+                { "==", TokenType.EqualTo, TokenSubType.Operator },
+                { "!=", TokenType.NotEqualTo, TokenSubType.Operator },
+                { ">", TokenType.GreaterThan, TokenSubType.Operator },
+                { ">=", TokenType.GreaterThanOrEqual, TokenSubType.Operator },
+                { "<", TokenType.LessThan, TokenSubType.Operator },
+                { "<=", TokenType.LessThanOrEqual, TokenSubType.Operator },
+                { "!", TokenType.Not, TokenSubType.Operator },
+                { "&&", TokenType.ConditionalAnd, TokenSubType.Operator },
+                { "||", TokenType.ConditionalOr, TokenSubType.Operator },
 
-                { "?", TokenType.QuestionMark },
-                { ":", TokenType.Colon },
-                { "->", TokenType.Pointy },
-                { "|>", TokenType.Pipeline },
-                { "...", TokenType.Ellipsis },
-                { "!in", TokenType.NotIn }
+                { "?", TokenType.QuestionMark, TokenSubType.Operator },
+                { ":", TokenType.Colon, TokenSubType.Operator },
+                { "->", TokenType.Pointy, TokenSubType.Operator },
+                { "|>", TokenType.Pipeline, TokenSubType.Operator },
+                { "...", TokenType.Ellipsis, TokenSubType.Operator },
+                { "!in", TokenType.NotIn, TokenSubType.None }
             };
 
             _keywords = new Dictionary<string, TokenType>
@@ -114,31 +114,31 @@ namespace Mond.Compiler
 
         class OperatorDictionary : IEnumerable<object>
         {
-            private readonly GenericComparer<Tuple<string, TokenType>> _comparer; 
-            private Dictionary<char, List<Tuple<string, TokenType>>> _operatorDictionary;
+            private readonly GenericComparer<Tuple<string, TokenType, TokenSubType>> _comparer; 
+            private Dictionary<char, List<Tuple<string, TokenType, TokenSubType>>> _operatorDictionary;
 
             public OperatorDictionary()
             {
-                _comparer = new GenericComparer<Tuple<string, TokenType>>((a, b) => b.Item1.Length - a.Item1.Length);
-                _operatorDictionary = new Dictionary<char, List<Tuple<string, TokenType>>>();
+                _comparer = new GenericComparer<Tuple<string, TokenType, TokenSubType>>((a, b) => b.Item1.Length - a.Item1.Length);
+                _operatorDictionary = new Dictionary<char, List<Tuple<string, TokenType, TokenSubType>>>();
             }
 
-            public void Add(string op, TokenType type)
+            public void Add(string op, TokenType type, TokenSubType subType)
             {
-                List<Tuple<string, TokenType>> list;
+                List<Tuple<string, TokenType, TokenSubType>> list;
                 if (!_operatorDictionary.TryGetValue(op[0], out list))
                 {
-                    list = new List<Tuple<string, TokenType>>();
+                    list = new List<Tuple<string, TokenType, TokenSubType>>();
                     _operatorDictionary.Add(op[0], list);
                 }
 
-                list.Add(Tuple.Create(op, type));
+                list.Add(Tuple.Create(op, type, subType));
                 list.Sort(_comparer);
             }
 
-            public IEnumerable<Tuple<string, TokenType>> Lookup(char ch)
+            public IEnumerable<Tuple<string, TokenType, TokenSubType>> Lookup(char ch)
             {
-                List<Tuple<string, TokenType>> list;
+                List<Tuple<string, TokenType, TokenSubType>> list;
                 if (!_operatorDictionary.TryGetValue(ch, out list))
                     return null;
 

--- a/Mond/Compiler/Lexer.cs
+++ b/Mond/Compiler/Lexer.cs
@@ -122,7 +122,7 @@ namespace Mond.Compiler
                 if (op != null)
                 {
                     var start = _positions.Pop();
-                    token = new Token(_fileName, start.Line, start.Column, op.Item2, op.Item1);
+                    token = new Token(_fileName, start.Line, start.Column, op.Item2, op.Item1, op.Item3);
                     return true;
                 }
 
@@ -256,7 +256,7 @@ namespace Mond.Compiler
             var isKeyword = _keywords.TryGetValue(wordContents, out keywordType);
 
             var start = _positions.Pop();
-            token = new Token(_fileName, start.Line, start.Column, isKeyword ? keywordType : TokenType.Identifier, wordContents);
+            token = new Token(_fileName, start.Line, start.Column, isKeyword ? keywordType : TokenType.Identifier, wordContents, isKeyword ? TokenSubType.Keyword : TokenSubType.None);
             return true;
         }
 
@@ -292,7 +292,7 @@ namespace Mond.Compiler
                     {
                         TakeChar(); // '0'
 
-                        token = new Token(_fileName, _currentLine, _currentColumn, TokenType.Number, "0", format);
+                        token = new Token(_fileName, _currentLine, _currentColumn, TokenType.Number, "0", tag: format);
                         return true;
                     }
 
@@ -358,7 +358,7 @@ namespace Mond.Compiler
             if (string.IsNullOrEmpty(numberContents))
                 throw new MondCompilerException(_fileName, start.Line, start.Column, CompilerError.EmptyNumber, format.GetName());
 
-            token =  new Token(_fileName, start.Line, start.Column, TokenType.Number, numberContents, format);
+            token =  new Token(_fileName, start.Line, start.Column, TokenType.Number, numberContents, tag: format);
             return true;
         }
 

--- a/Mond/Compiler/Parselets/BinaryOperatorParselet.cs
+++ b/Mond/Compiler/Parselets/BinaryOperatorParselet.cs
@@ -18,33 +18,12 @@ namespace Mond.Compiler.Parselets
 
         public Expression Parse(Parser parser, Expression left, Token token)
         {
-            Expression right;
+            var right = parser.ParseExpression(Precedence - (_isRight ? 1 : 0));
 
-            if (token.SubType == TokenSubType.Operator)
-            {
-                var @operator = new StringBuilder(token.Contents);
-                var tokenCount = 1;
-
-                while( parser.Match( TokenSubType.Operator ) )
-                {
-                    @operator.Append( parser.Take().Contents );
-                    ++tokenCount;
-                }
-
-                var opStr = @operator.ToString();
-                if (tokenCount == 1 && opStr != "..." && opStr != "~")
-                {
-                    right = parser.ParseExpression(Precedence - (_isRight ? 1 : 0));
-                    return new BinaryOperatorExpression(token, left, right);
-                }
-
-                token = new Token(token, TokenType.UserDefinedOperator, opStr, TokenSubType.Operator);
-                right = parser.ParseExpression((int)PrecedenceValue.Relational);
-                return new UserDefinedBinaryOperatorExpression(token, left, right, token.Contents);
-            }
-
-            right = parser.ParseExpression(Precedence - (_isRight ? 1 : 0));
-            return new BinaryOperatorExpression(token, left, right);
+            if (token.Type == TokenType.UserDefinedOperator)
+                return new UserDefinedBinaryOperatorExpression(token, left, right);
+            else
+                return new BinaryOperatorExpression(token, left, right);
         }
     }
 }

--- a/Mond/Compiler/Parselets/BinaryOperatorParselet.cs
+++ b/Mond/Compiler/Parselets/BinaryOperatorParselet.cs
@@ -27,7 +27,14 @@ namespace Mond.Compiler.Parselets
                 while (parser.Match(TokenSubType.Operator))
                     @operator.Append(parser.Take().Contents);
 
-                token = new Token(token, TokenType.UserDefinedOperator, @operator.ToString(), TokenSubType.Operator);
+                var opStr = @operator.ToString();
+                if (opStr != "...")
+                {
+                    right = parser.ParseExpression(Precedence - (_isRight ? 1 : 0));
+                    return new BinaryOperatorExpression(token, left, right);
+                }
+
+                token = new Token(token, TokenType.UserDefinedOperator, opStr, TokenSubType.Operator);
                 right = parser.ParseExpression((int)PrecedenceValue.Relational);
                 return new UserDefinedBinaryOperatorExpression(token, left, right, token.Contents);
             }

--- a/Mond/Compiler/Parselets/BinaryOperatorParselet.cs
+++ b/Mond/Compiler/Parselets/BinaryOperatorParselet.cs
@@ -23,12 +23,16 @@ namespace Mond.Compiler.Parselets
             if (token.SubType == TokenSubType.Operator)
             {
                 var @operator = new StringBuilder(token.Contents);
+                var tokenCount = 1;
 
-                while (parser.Match(TokenSubType.Operator))
-                    @operator.Append(parser.Take().Contents);
+                while( parser.Match( TokenSubType.Operator ) )
+                {
+                    @operator.Append( parser.Take().Contents );
+                    ++tokenCount;
+                }
 
                 var opStr = @operator.ToString();
-                if (opStr != "...")
+                if (tokenCount == 1 && opStr != "..." && opStr != "~")
                 {
                     right = parser.ParseExpression(Precedence - (_isRight ? 1 : 0));
                     return new BinaryOperatorExpression(token, left, right);

--- a/Mond/Compiler/Parselets/BinaryOperatorParselet.cs
+++ b/Mond/Compiler/Parselets/BinaryOperatorParselet.cs
@@ -1,4 +1,5 @@
-﻿using Mond.Compiler.Expressions;
+﻿using System.Text;
+using Mond.Compiler.Expressions;
 
 namespace Mond.Compiler.Parselets
 {
@@ -17,7 +18,21 @@ namespace Mond.Compiler.Parselets
 
         public Expression Parse(Parser parser, Expression left, Token token)
         {
-            var right = parser.ParseExpression(Precedence - (_isRight ? 1 : 0));
+            Expression right;
+
+            if (token.SubType == TokenSubType.Operator)
+            {
+                var @operator = new StringBuilder(token.Contents);
+
+                while (parser.Match(TokenSubType.Operator))
+                    @operator.Append(parser.Take().Contents);
+
+                token = new Token(token, TokenType.UserDefinedOperator, @operator.ToString(), TokenSubType.Operator);
+                right = parser.ParseExpression((int)PrecedenceValue.Relational);
+                return new UserDefinedBinaryOperatorExpression(token, left, right, token.Contents);
+            }
+
+            right = parser.ParseExpression(Precedence - (_isRight ? 1 : 0));
             return new BinaryOperatorExpression(token, left, right);
         }
     }

--- a/Mond/Compiler/Parselets/GroupParselet.cs
+++ b/Mond/Compiler/Parselets/GroupParselet.cs
@@ -52,7 +52,7 @@ namespace Mond.Compiler.Parselets
             parser.Take(TokenType.Pointy);
 
             var body = FunctionParselet.ParseLambdaExpressionBody(parser, token);
-            return new FunctionExpression(token, null, arguments, otherArgs, body);
+            return new FunctionExpression(token, null, arguments, otherArgs, false, body);
         }
     }
 }

--- a/Mond/Compiler/Parselets/IdentifierParselet.cs
+++ b/Mond/Compiler/Parselets/IdentifierParselet.cs
@@ -23,7 +23,7 @@ namespace Mond.Compiler.Parselets
             };
 
             var body = FunctionParselet.ParseLambdaExpressionBody(parser, token);
-            return new FunctionExpression(token, null, arguments, null, body);
+            return new FunctionExpression(token, null, arguments, null, false, body);
         }
     }
 }

--- a/Mond/Compiler/Parselets/PrefixOperatorParselet.cs
+++ b/Mond/Compiler/Parselets/PrefixOperatorParselet.cs
@@ -23,7 +23,14 @@ namespace Mond.Compiler.Parselets
                 while (parser.Match(TokenSubType.Operator))
                     @operator.Append(parser.Take().Contents);
 
-                token = new Token(token, TokenType.UserDefinedOperator, @operator.ToString());
+                var opStr = @operator.ToString();
+                if (opStr == "++" || opStr == "--" || opStr == "-" || opStr == "+" || opStr == "!" || opStr == "~")
+                {
+                    right = parser.ParseExpression(_precedence);
+                    return new PrefixOperatorExpression(token, right);
+                }
+
+                token = new Token(token, TokenType.UserDefinedOperator, opStr);
                 right = parser.ParseExpression((int)PrecedenceValue.Prefix);
                 return new UserDefinedUnaryOperator(token, right, token.Contents);
             }

--- a/Mond/Compiler/Parselets/PrefixOperatorParselet.cs
+++ b/Mond/Compiler/Parselets/PrefixOperatorParselet.cs
@@ -14,33 +14,12 @@ namespace Mond.Compiler.Parselets
 
         public Expression Parse(Parser parser, Token token)
         {
-            Expression right;
+            var right = parser.ParseExpression(_precedence);
 
-            if (token.SubType == TokenSubType.Operator)
-            {
-                var @operator = new StringBuilder(token.Contents);
-                var tokenCount = 1;
-
-                while (parser.Match(TokenSubType.Operator))
-                {
-                    @operator.Append( parser.Take().Contents );
-                    ++tokenCount;
-                }
-
-                var opStr = @operator.ToString();
-                if (tokenCount == 1 && (opStr == "++" || opStr == "--" || opStr == "-" || opStr == "+" || opStr == "!" || opStr == "~"))
-                {
-                    right = parser.ParseExpression(_precedence);
-                    return new PrefixOperatorExpression(token, right);
-                }
-
-                token = new Token(token, TokenType.UserDefinedOperator, opStr);
-                right = parser.ParseExpression((int)PrecedenceValue.Prefix);
-                return new UserDefinedUnaryOperator(token, right, token.Contents);
-            }
-
-            right = parser.ParseExpression(_precedence);
-            return new PrefixOperatorExpression(token, right);
+            if (token.Type == TokenType.UserDefinedOperator)
+                return new UserDefinedUnaryOperator(token, right);
+            else
+                return new PrefixOperatorExpression(token, right);
         }
     }
 }

--- a/Mond/Compiler/Parselets/PrefixOperatorParselet.cs
+++ b/Mond/Compiler/Parselets/PrefixOperatorParselet.cs
@@ -19,12 +19,16 @@ namespace Mond.Compiler.Parselets
             if (token.SubType == TokenSubType.Operator)
             {
                 var @operator = new StringBuilder(token.Contents);
+                var tokenCount = 1;
 
                 while (parser.Match(TokenSubType.Operator))
-                    @operator.Append(parser.Take().Contents);
+                {
+                    @operator.Append( parser.Take().Contents );
+                    ++tokenCount;
+                }
 
                 var opStr = @operator.ToString();
-                if (opStr == "++" || opStr == "--" || opStr == "-" || opStr == "+" || opStr == "!" || opStr == "~")
+                if (tokenCount == 1 && (opStr == "++" || opStr == "--" || opStr == "-" || opStr == "+" || opStr == "!" || opStr == "~"))
                 {
                     right = parser.ParseExpression(_precedence);
                     return new PrefixOperatorExpression(token, right);

--- a/Mond/Compiler/Parselets/PrefixOperatorParselet.cs
+++ b/Mond/Compiler/Parselets/PrefixOperatorParselet.cs
@@ -1,4 +1,5 @@
-﻿using Mond.Compiler.Expressions;
+﻿using System.Text;
+using Mond.Compiler.Expressions;
 
 namespace Mond.Compiler.Parselets
 {
@@ -13,7 +14,21 @@ namespace Mond.Compiler.Parselets
 
         public Expression Parse(Parser parser, Token token)
         {
-            var right = parser.ParseExpression(_precedence);
+            Expression right;
+
+            if (token.SubType == TokenSubType.Operator)
+            {
+                var @operator = new StringBuilder(token.Contents);
+
+                while (parser.Match(TokenSubType.Operator))
+                    @operator.Append(parser.Take().Contents);
+
+                token = new Token(token, TokenType.UserDefinedOperator, @operator.ToString());
+                right = parser.ParseExpression((int)PrecedenceValue.Prefix);
+                return new UserDefinedUnaryOperator(token, right, token.Contents);
+            }
+
+            right = parser.ParseExpression(_precedence);
             return new PrefixOperatorExpression(token, right);
         }
     }

--- a/Mond/Compiler/Parselets/Statements/FunctionParselet.cs
+++ b/Mond/Compiler/Parselets/Statements/FunctionParselet.cs
@@ -59,15 +59,11 @@ namespace Mond.Compiler.Parselets.Statements
             {
                 if (parser.MatchAndTake(TokenType.LeftParen))
                 {
-                    var @operator = new StringBuilder();
-
-                    do @operator.Append(parser.Take(TokenSubType.Operator).Contents);
-                    while (!parser.Match(TokenType.RightParen));
-
+                    var operatorToken = parser.Take( TokenType.UserDefinedOperator );
                     parser.Take(TokenType.RightParen);
 
                     isOperator = true;
-                    name = @operator.ToString();
+                    name = operatorToken.Contents;
                 }
                 else
                 {

--- a/Mond/Compiler/Parselets/Statements/FunctionParselet.cs
+++ b/Mond/Compiler/Parselets/Statements/FunctionParselet.cs
@@ -103,14 +103,6 @@ namespace Mond.Compiler.Parselets.Statements
 
                 if (otherArgs != null)
                     throw new MondCompilerException(token, CompilerError.EllipsisInOperator);
-
-                // Check to see if we're trying to override any built-in unary prefix operators
-                if (arguments.Count == 1 && Lexer.OperatorExists(name) && (name == "++" || name == "--" || name == "+" || name == "-" || name == "!" || name == "~"))
-                    throw new MondCompilerException(token, CompilerError.CantOverrideBuiltInOperator, name);
-
-                // Check to see if we're trying to override any built-in unary postfix or binary operators
-                if (arguments.Count == 2 && Lexer.OperatorExists(name.ToString()) && name != "..." && name != "~")
-                    throw new MondCompilerException(token, CompilerError.CantOverrideBuiltInOperator, name);
             }
 
             // parse body

--- a/Mond/Compiler/Parselets/Statements/FunctionParselet.cs
+++ b/Mond/Compiler/Parselets/Statements/FunctionParselet.cs
@@ -113,7 +113,7 @@ namespace Mond.Compiler.Parselets.Statements
                     throw new MondCompilerException(token, CompilerError.CantOverrideBuiltInOperator, name);
 
                 // Check to see if we're trying to override any built-in unary postfix or binary operators
-                if (arguments.Count == 2 && Lexer.OperatorExists(name.ToString()) && name != "...")
+                if (arguments.Count == 2 && Lexer.OperatorExists(name.ToString()) && name != "..." && name != "~")
                     throw new MondCompilerException(token, CompilerError.CantOverrideBuiltInOperator, name);
             }
 

--- a/Mond/Compiler/Parselets/Statements/FunctionParselet.cs
+++ b/Mond/Compiler/Parselets/Statements/FunctionParselet.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Text;
+using System.Collections.Generic;
 using Mond.Compiler.Expressions;
 using Mond.Compiler.Expressions.Statements;
 
@@ -11,11 +12,13 @@ namespace Mond.Compiler.Parselets.Statements
             string name;
             List<string> arguments;
             string otherArgs;
+            bool isOperator;
             ScopeExpression body;
 
-            ParseFunction(parser, token, true, out trailingSemicolon, out name, out arguments, out otherArgs, out body);
+            ParseFunction(parser, token, true, out trailingSemicolon, out name, out arguments, out otherArgs, out isOperator, out body);
+            var function = new FunctionExpression(token, isOperator ? null : name, arguments, otherArgs, body);
 
-            return new FunctionExpression(token, name, arguments, otherArgs, body);
+            return isOperator ? MakeOperator(name, function) : function;
         }
 
         public Expression Parse(Parser parser, Token token)
@@ -24,11 +27,13 @@ namespace Mond.Compiler.Parselets.Statements
             List<string> arguments;
             string otherArgs;
             ScopeExpression body;
+            bool isOperator;
             bool trailingSemicolon;
 
-            ParseFunction(parser, token, false, out trailingSemicolon, out name, out arguments, out otherArgs, out body);
+            ParseFunction(parser, token, false, out trailingSemicolon, out name, out arguments, out otherArgs, out isOperator, out body);
+            var function = new FunctionExpression(token, isOperator ? null : name, arguments, otherArgs, body);
 
-            return new FunctionExpression(token, name, arguments, otherArgs, body);
+            return isOperator ? MakeOperator(name, function) : function;
         }
 
         public static void ParseFunction(
@@ -39,6 +44,7 @@ namespace Mond.Compiler.Parselets.Statements
             out string name,
             out List<string> arguments,
             out string otherArgs,
+            out bool isOperator,
             out ScopeExpression body)
         {
             trailingSemicolon = false;
@@ -46,10 +52,35 @@ namespace Mond.Compiler.Parselets.Statements
             name = null;
             arguments = new List<string>();
             otherArgs = null;
+            isOperator = false;
 
             // only statements can be named
             if (isStatement)
-                name = parser.Take(TokenType.Identifier).Contents;
+            {
+                if (parser.MatchAndTake(TokenType.LeftParen))
+                {
+                    var @operator = new StringBuilder();
+
+                    do
+                    {
+                        @operator.Append(parser.Take(TokenSubType.Operator).Contents);
+
+                        if (parser.Match(TokenType.RightParen))
+                            break;
+
+                        parser.Take(TokenType.Comma);
+                    } while (!parser.Match(TokenType.RightParen));
+
+                    parser.Take(TokenType.RightParen);
+
+                    isOperator = true;
+                    name = @operator.ToString();
+                }
+                else
+                {
+                    name = parser.Take(TokenType.Identifier).Contents;
+                }
+            }
 
             // parse argument list
             parser.Take(TokenType.LeftParen);
@@ -76,6 +107,12 @@ namespace Mond.Compiler.Parselets.Statements
 
             parser.Take(TokenType.RightParen);
 
+            if (isOperator && arguments.Count != 1 && arguments.Count != 2)
+                throw new MondCompilerException(token, CompilerError.IncorrectOperatorArity, arguments.Count);
+
+            if (isOperator && otherArgs != null)
+                throw new MondCompilerException(token, CompilerError.EllipsisInOperator);
+
             // parse body
             if (parser.MatchAndTake(TokenType.Pointy))
             {
@@ -101,6 +138,23 @@ namespace Mond.Compiler.Parselets.Statements
             {
                 new ReturnExpression(parser.Peek(), parser.ParseExpression())
             });
+        }
+
+        public static Expression MakeOperator(string @operator, FunctionExpression function)
+        {
+            var token = new Token(function.Token, TokenType.Global, "global", TokenSubType.Keyword);
+            var global = new GlobalExpression(token);
+
+            token = new Token(function.Token, TokenType.String, "$ops", TokenSubType.None);
+            var opsString = new StringExpression(token, token.Contents);
+            var opsField = new IndexerExpression(token, global, opsString);
+
+            token = new Token(function.Token, TokenType.String, @operator, TokenSubType.Operator);
+            var opIndex = new StringExpression(token, token.Contents);
+            var opField = new IndexerExpression(token, opsField, opIndex);
+
+            token = new Token(function.Token, TokenType.Assign, "=", TokenSubType.Operator);
+            return new BinaryOperatorExpression(token, opField, function);
         }
     }
 }

--- a/Mond/Compiler/Parselets/Statements/SequenceParselet.cs
+++ b/Mond/Compiler/Parselets/Statements/SequenceParselet.cs
@@ -11,11 +11,13 @@ namespace Mond.Compiler.Parselets.Statements
             string name;
             List<string> arguments;
             string otherArgs;
+            bool isOperator;
             ScopeExpression body;
 
-            FunctionParselet.ParseFunction(parser, token, true, out trailingSemicolon, out name, out arguments, out otherArgs, out body);
+            FunctionParselet.ParseFunction(parser, token, true, out trailingSemicolon, out name, out arguments, out otherArgs, out isOperator, out body);
+            var sequence = new SequenceExpression(token, isOperator ? null : name, arguments, otherArgs, body);
 
-            return new SequenceExpression(token, name, arguments, otherArgs, body);
+            return isOperator ? FunctionParselet.MakeOperator(name, sequence) : sequence;
         }
 
         public Expression Parse(Parser parser, Token token)
@@ -23,12 +25,14 @@ namespace Mond.Compiler.Parselets.Statements
             string name;
             List<string> arguments;
             string otherArgs;
+            bool isOperator;
             ScopeExpression body;
             bool trailingSemicolon;
 
-            FunctionParselet.ParseFunction(parser, token, false, out trailingSemicolon, out name, out arguments, out otherArgs, out body);
+            FunctionParselet.ParseFunction(parser, token, false, out trailingSemicolon, out name, out arguments, out otherArgs, out isOperator, out body);
+            var sequence = new SequenceExpression(token, isOperator ? null : name, arguments, otherArgs, body);
 
-            return new SequenceExpression(token, name, arguments, otherArgs, body);
+            return isOperator ? FunctionParselet.MakeOperator(name, sequence) : sequence;
         }
     }
 }

--- a/Mond/Compiler/Parselets/Statements/SequenceParselet.cs
+++ b/Mond/Compiler/Parselets/Statements/SequenceParselet.cs
@@ -15,7 +15,7 @@ namespace Mond.Compiler.Parselets.Statements
             ScopeExpression body;
 
             FunctionParselet.ParseFunction(parser, token, true, out trailingSemicolon, out name, out arguments, out otherArgs, out isOperator, out body);
-            var sequence = new SequenceExpression(token, isOperator ? null : name, arguments, otherArgs, body);
+            var sequence = new SequenceExpression(token, name, arguments, otherArgs, isOperator, body);
 
             return isOperator ? FunctionParselet.MakeOperator(name, sequence) : sequence;
         }
@@ -30,7 +30,7 @@ namespace Mond.Compiler.Parselets.Statements
             bool trailingSemicolon;
 
             FunctionParselet.ParseFunction(parser, token, false, out trailingSemicolon, out name, out arguments, out otherArgs, out isOperator, out body);
-            var sequence = new SequenceExpression(token, isOperator ? null : name, arguments, otherArgs, body);
+            var sequence = new SequenceExpression(token, name, arguments, otherArgs, isOperator, body);
 
             return isOperator ? FunctionParselet.MakeOperator(name, sequence) : sequence;
         }

--- a/Mond/Compiler/Parser.Static.cs
+++ b/Mond/Compiler/Parser.Static.cs
@@ -59,7 +59,39 @@ namespace Mond.Compiler
             RegisterInfix(TokenType.LessThanOrEqual, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
             RegisterInfix(TokenType.In, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
             RegisterInfix(TokenType.NotIn, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
+
+            // UDO stuff. We need to add all these so UDOs can parse correctly
             RegisterInfix(TokenType.Ellipsis, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
+            RegisterInfix(TokenType.BitNot, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
+            RegisterPrefix(TokenType.Modulo, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.Exponent, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.Multiply, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.Divide, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.BitAnd, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.BitOr, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.BitXor, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.BitLeftShift, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.BitRightShift, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.Dot, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.Pipeline, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.EqualTo, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.NotEqualTo, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.GreaterThan, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.GreaterThanOrEqual, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.LessThan, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.LessThanOrEqual, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.ConditionalAnd, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.ConditionalOr, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.QuestionMark, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.ModuloAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.ExponentAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.MultiplyAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.DivideAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.BitAndAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.BitOrAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.BitXorAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.BitLeftShiftAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.BitRightShiftAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
 
             // prefix inc/decrement
             RegisterPrefix(TokenType.Increment, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));

--- a/Mond/Compiler/Parser.Static.cs
+++ b/Mond/Compiler/Parser.Static.cs
@@ -42,6 +42,7 @@ namespace Mond.Compiler
             RegisterInfix(TokenType.BitOr, new BinaryOperatorParselet((int)PrecedenceValue.BitOr, false));
             RegisterInfix(TokenType.BitXor, new BinaryOperatorParselet((int)PrecedenceValue.BitXor, false));
             RegisterPrefix(TokenType.Subtract, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterPrefix(TokenType.Add, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
             RegisterPrefix(TokenType.BitNot, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
 
             // conditional operations
@@ -58,6 +59,7 @@ namespace Mond.Compiler
             RegisterInfix(TokenType.LessThanOrEqual, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
             RegisterInfix(TokenType.In, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
             RegisterInfix(TokenType.NotIn, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
+            RegisterInfix(TokenType.Ellipsis, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
 
             // prefix inc/decrement
             RegisterPrefix(TokenType.Increment, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));

--- a/Mond/Compiler/Parser.Static.cs
+++ b/Mond/Compiler/Parser.Static.cs
@@ -61,37 +61,8 @@ namespace Mond.Compiler
             RegisterInfix(TokenType.NotIn, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
 
             // UDO stuff. We need to add all these so UDOs can parse correctly
-            RegisterInfix(TokenType.Ellipsis, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
-            RegisterInfix(TokenType.BitNot, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
-            RegisterPrefix(TokenType.Modulo, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.Exponent, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.Multiply, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.Divide, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.BitAnd, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.BitOr, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.BitXor, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.BitLeftShift, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.BitRightShift, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.Dot, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.Pipeline, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.EqualTo, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.NotEqualTo, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.GreaterThan, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.GreaterThanOrEqual, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.LessThan, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.LessThanOrEqual, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.ConditionalAnd, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.ConditionalOr, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.QuestionMark, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.ModuloAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.ExponentAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.MultiplyAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.DivideAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.BitAndAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.BitOrAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.BitXorAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.BitLeftShiftAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
-            RegisterPrefix(TokenType.BitRightShiftAssign, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
+            RegisterInfix(TokenType.UserDefinedOperator, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
+            RegisterPrefix(TokenType.UserDefinedOperator, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
 
             // prefix inc/decrement
             RegisterPrefix(TokenType.Increment, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));

--- a/Mond/Compiler/Parser.cs
+++ b/Mond/Compiler/Parser.cs
@@ -151,11 +151,31 @@ namespace Mond.Compiler
         }
 
         /// <summary>
+        /// Check if the next token matches the given subtype. If they match, take the token.
+        /// </summary>
+        public bool MatchAndTake(TokenSubType subType)
+        {
+            var isMatch = Match(subType);
+            if (isMatch)
+                Take();
+
+            return isMatch;
+        }
+
+        /// <summary>
         /// Check if the next token matches the given type.
         /// </summary>
         public bool Match(TokenType type, int distance = 0)
         {
             return Peek(distance).Type == type;
+        }
+
+        /// <summary>
+        /// Check if the next token matches the given subtype.
+        /// </summary>
+        public bool Match(TokenSubType subType, int distance = 0)
+        {
+            return Peek(distance).SubType == subType;
         }
 
         /// <summary>
@@ -167,6 +187,19 @@ namespace Mond.Compiler
 
             if (token.Type != type)
                 throw new MondCompilerException(token, CompilerError.ExpectedButFound, type, token);
+
+            return token;
+        }
+
+        /// <summary>
+        /// Take a token from the stream. Throws an exception if the given subtype does not match the token subtype.
+        /// </summary>
+        public Token Take(TokenSubType subType)
+        {
+            var token = Take();
+
+            if (token.SubType != subType)
+                throw new MondCompilerException(token, CompilerError.ExpectedButFound, subType, token);
 
             return token;
         }

--- a/Mond/Compiler/Token.cs
+++ b/Mond/Compiler/Token.cs
@@ -1,5 +1,13 @@
 ﻿namespace Mond.Compiler
 {
+    enum TokenSubType
+    {
+        None,
+        Keyword,
+        Operator,
+        Punctuation,
+    }
+
     enum TokenType
     {
         Identifier,
@@ -91,6 +99,7 @@
         Pointy,
         Pipeline,
         Ellipsis,
+        UserDefinedOperator,
 
         Eof
     }
@@ -101,21 +110,23 @@
         public readonly int Line;
         public readonly int Column;
         public readonly TokenType Type;
+        public readonly TokenSubType SubType;
         public readonly string Contents;
         public readonly object Tag;
 
-        public Token(string fileName, int line, int column, TokenType type, string contents, object tag = null)
+        public Token(string fileName, int line, int column, TokenType type, string contents, TokenSubType subType = TokenSubType.None, object tag = null)
         {
             FileName = fileName;
             Line = line;
             Column = column;
             Type = type;
+            SubType = subType;
             Contents = contents;
             Tag = tag;
         }
 
-        public Token(Token token, TokenType type, string contents, object tag = null)
-            : this(token.FileName, token.Line, token.Column, type, contents, tag)
+        public Token(Token token, TokenType type, string contents, TokenSubType subType = TokenSubType.None, object tag = null)
+            : this(token.FileName, token.Line, token.Column, type, contents, subType, tag)
         {
 
         }
@@ -134,7 +145,7 @@
                     return string.Format("{0}('{1}')", Type, contentsStr);
 
                 default:
-                    return Type.ToString();
+                    return string.Format("{0}({1})", Type, SubType);
             }
         }
     }

--- a/Mond/Compiler/Visitors/ExpressionPrintVisitor.cs
+++ b/Mond/Compiler/Visitors/ExpressionPrintVisitor.cs
@@ -584,6 +584,24 @@ namespace Mond.Compiler.Visitors
             return 0;
         }
 
+        public int Visit(UserDefinedUnaryOperator expression)
+        {
+            _writer.Write(expression.Operator);
+            expression.Right.Accept(this);
+
+            return 0;
+        }
+
+        public int Visit(UserDefinedBinaryOperatorExpression expression)
+        {
+            expression.Left.Accept(this);
+            _writer.Write(expression.Operator);
+            expression.Right.Accept(this);
+
+            return 0;
+        }
+
         #endregion
+
     }
 }

--- a/Mond/Compiler/Visitors/ExpressionRewriteVisitor.cs
+++ b/Mond/Compiler/Visitors/ExpressionRewriteVisitor.cs
@@ -69,6 +69,7 @@ namespace Mond.Compiler.Visitors
                 expression.Name,
                 expression.Arguments.ToList(),
                 expression.OtherArguments,
+                expression.IsOperator,
                 (ScopeExpression)expression.Block.Accept(this),
                 expression.DebugName)
             {
@@ -109,6 +110,7 @@ namespace Mond.Compiler.Visitors
                 expression.Name,
                 expression.Arguments.ToList(),
                 expression.OtherArguments,
+                expression.IsOperator,
                 (ScopeExpression)expression.Block.Accept(this),
                 expression.DebugName)
             {

--- a/Mond/Compiler/Visitors/ExpressionRewriteVisitor.cs
+++ b/Mond/Compiler/Visitors/ExpressionRewriteVisitor.cs
@@ -347,5 +347,22 @@ namespace Mond.Compiler.Visitors
                 EndToken = expression.EndToken
             };
         }
+
+
+        public Expression Visit(UserDefinedUnaryOperator expression)
+        {
+            return new UserDefinedUnaryOperator(expression.Token, expression.Right.Accept(this), expression.Operator)
+            {
+                EndToken = expression.EndToken
+            };
+        }
+
+        public Expression Visit(UserDefinedBinaryOperatorExpression expression)
+        {
+            return new UserDefinedBinaryOperatorExpression(expression.Token, expression.Left.Accept(this), expression.Right.Accept(this), expression.Operator)
+            {
+                EndToken = expression.EndToken
+            };
+        }
     }
 }

--- a/Mond/Compiler/Visitors/ExpressionRewriteVisitor.cs
+++ b/Mond/Compiler/Visitors/ExpressionRewriteVisitor.cs
@@ -353,7 +353,7 @@ namespace Mond.Compiler.Visitors
 
         public Expression Visit(UserDefinedUnaryOperator expression)
         {
-            return new UserDefinedUnaryOperator(expression.Token, expression.Right.Accept(this), expression.Operator)
+            return new UserDefinedUnaryOperator(expression.Token, expression.Right.Accept(this))
             {
                 EndToken = expression.EndToken
             };
@@ -361,7 +361,7 @@ namespace Mond.Compiler.Visitors
 
         public Expression Visit(UserDefinedBinaryOperatorExpression expression)
         {
-            return new UserDefinedBinaryOperatorExpression(expression.Token, expression.Left.Accept(this), expression.Right.Accept(this), expression.Operator)
+            return new UserDefinedBinaryOperatorExpression(expression.Token, expression.Left.Accept(this), expression.Right.Accept(this))
             {
                 EndToken = expression.EndToken
             };

--- a/Mond/Compiler/Visitors/ExpressionVisitor.cs
+++ b/Mond/Compiler/Visitors/ExpressionVisitor.cs
@@ -295,5 +295,21 @@ namespace Mond.Compiler
 
             return default(T);
         }
+
+
+        public T Visit(UserDefinedUnaryOperator expression)
+        {
+            expression.Right.Accept(this);
+
+            return default(T);
+        }
+
+        public T Visit(UserDefinedBinaryOperatorExpression expression)
+        {
+            expression.Left.Accept(this);
+            expression.Right.Accept(this);
+
+            return default(T);
+        }
     }
 }

--- a/Mond/Compiler/Visitors/IExpressionVisitor.cs
+++ b/Mond/Compiler/Visitors/IExpressionVisitor.cs
@@ -42,5 +42,7 @@ namespace Mond.Compiler
         T Visit(TernaryExpression expression);
         T Visit(UndefinedExpression expression);
         T Visit(UnpackExpression expression);
+        T Visit(UserDefinedUnaryOperator expression);
+        T Visit(UserDefinedBinaryOperatorExpression expression);
     }
 }

--- a/Mond/Mond.csproj
+++ b/Mond/Mond.csproj
@@ -86,6 +86,8 @@
     <Compile Include="Compiler\Expressions\Statements\DebuggerExpression.cs" />
     <Compile Include="Compiler\Expressions\Statements\ForeachExpression.cs" />
     <Compile Include="Compiler\Expressions\Statements\SequenceExpression.cs" />
+    <Compile Include="Compiler\Expressions\UserDefinedBinaryOperatorExpression.cs" />
+    <Compile Include="Compiler\Expressions\UserDefinedUnaryOperator.cs" />
     <Compile Include="Compiler\Expressions\YieldExpression.cs" />
     <Compile Include="Compiler\Expressions\UnpackExpression.cs" />
     <Compile Include="Compiler\LoopContext.cs" />

--- a/Mond/Mond.csproj
+++ b/Mond/Mond.csproj
@@ -76,6 +76,9 @@
     <Compile Include="Binding\MondInstanceAttribute.cs" />
     <Compile Include="Binding\MondModuleAttribute.cs" />
     <Compile Include="Binding\MondModuleBinder.cs" />
+    <Compile Include="Binding\MondOperatorAttribute.cs" />
+    <Compile Include="Binding\MondOperatorModuleAttribute.cs" />
+    <Compile Include="Binding\MondOperatorModuleBinder.cs" />
     <Compile Include="Binding\MondPrototypeBinder.cs" />
     <Compile Include="Compiler\CompilerError.cs" />
     <Compile Include="Compiler\ConstantPool.cs" />
@@ -242,7 +245,6 @@
   <ItemGroup>
     <Compile Include="Compiler\Lexer.Static.cs" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Mond/VirtualMachine/Machine.cs
+++ b/Mond/VirtualMachine/Machine.cs
@@ -23,7 +23,7 @@ namespace Mond.VirtualMachine
         {
             _state = state;
             Global = new MondValue(MondValueType.Object);
-            Global["$ops"] = new MondValue(MondValueType.Object);
+            Global["__ops"] = new MondValue(MondValueType.Object);
 
             _debugAction = MondDebugAction.Run;
             _debugSkip = false;

--- a/Mond/VirtualMachine/Machine.cs
+++ b/Mond/VirtualMachine/Machine.cs
@@ -23,6 +23,7 @@ namespace Mond.VirtualMachine
         {
             _state = state;
             Global = new MondValue(MondValueType.Object);
+            Global["$ops"] = new MondValue(MondValueType.Object);
 
             _debugAction = MondDebugAction.Run;
             _debugSkip = false;


### PR DESCRIPTION
Doing the legwork for #35.

**TODO**:

- [x] Get basic support for UDOs working.
- [x] Enforce the following rules for all UDOs
  - [x] 1.) UDOs may not override existing operators*
    - \* ~~Unless the UDO has a different arity from the built-in form, e.g. creating a binary `...`~~
  - [x] 2.) UDOs may only be made-up of tokens that define pre-existing operators as long as the new UDO does not conflict with the previous rule
  - [x] 3.) Unary UDOs are prefix-only
  - [x] 4.) UDO function declaration arity must be either 1 or 2, defining it as a unary or binary operator
  - [x] 5.) UDOs cannot have an ellipsis argument
- [x] Add unit tests
- [x] Add ability to define UDOs via the binding API

**Specifics**

UDOs are defined like normal function/sequence statements, but in place of an identifier name, the operator token is enclosed in parentheses:

```
fun( <token> )( <arguments> ) {
    <body>
}

seq( <token> )( <arguments> ) {
    <body>
}
```

These declarations are transformed into function/sequence expressions, and then stored in a global `$ops` object under the name `<token>` (if the programmer so-chooses, UDOs may also be defined in this way, but this way will not be able to circumvent overriding the built-in operators):

```
global["__ops"]["<token>"] = fun( <arguments> ) {
    <body>
};

global["__ops"]["<token>"] = seq( <arguments> ) {
    <body>
};
```

Usage of any UDO is transformed to call the function stored in `global["__ops"]["<token>"]`:

```
seq( ... )( begin, end ) {
    for( var i = begin; i < end; ++i )
        yield i;
}

var oneToFour = 1 ... 5;
```

Becomes:

```
global["__ops"]["..."] = seq( begin, end ) {
    for( var i = begin; i < end; ++i )
        yield i;
};

var oneToFour = global["__ops"]["..."]( 1, 5 );
```

**More examples**

```
// Forward function compositing
fun( >>> )( func1, func2 ) {
    return fun( ... args ) {
        func1( ... args ) |> func2();
    }
}

fun double( n ) -> n *  2;
fun square( n ) -> n ** 2;

// Same as double( square( n ) );
const doubleSquare = square >>> double;

printLn( doubleSquare( 5 ) ); //=> 50

//Back-piping
fun( <| )( func, arg ) {
    func( arg );
}

var nums = [ 1, 2, 3, 4, 5 ];
var doubles = Seq.map <| fun( n ) {
    return n * 2;
}
```