### PR TITLE
Destructuring assignment

### DIFF
--- a/Mond.Tests/Expressions/DestructuringTests.cs
+++ b/Mond.Tests/Expressions/DestructuringTests.cs
@@ -41,6 +41,19 @@ namespace Mond.Tests.Expressions
             Assert.True(result[1].Array.SequenceEqual(expectMiddle));
             Assert.True(result[2].Array.SequenceEqual(expectEnd));
 
+            result = Script.Run(@"
+                var array = [ 1, 2 ];
+                var [ x, ...y, z ] = array;
+
+                return [ x, y, z ];
+            ");
+
+            var emptyArray = new MondValue[0];
+
+            Assert.AreEqual((int)result[0], 1);
+            Assert.True(result[1].Array.SequenceEqual(emptyArray));
+            Assert.AreEqual((int)result[2], 2);
+
             var multipleEllipsis = @"
                 var array = [ 1, 2, 3, 4, 5 ];
                 var [ ...head, middle, ...tail ] = array;

--- a/Mond.Tests/Expressions/DestructuringTests.cs
+++ b/Mond.Tests/Expressions/DestructuringTests.cs
@@ -6,7 +6,7 @@ namespace Mond.Tests.Expressions
     [TestFixture]
     public class DestructuringTests
     {
-        [TestCase]
+        [Test]
         public void BasicArrayDestructuring()
         {
             var result = Script.Run(@"
@@ -21,7 +21,7 @@ namespace Mond.Tests.Expressions
             Assert.True(result.Array.SequenceEqual(expected));
         }
 
-        [TestCase]
+        [Test]
         public void ArrayEllipsisDestructuring()
         {
             var result = Script.Run(@"
@@ -40,9 +40,16 @@ namespace Mond.Tests.Expressions
             Assert.True(result[0].Array.SequenceEqual(expectStart));
             Assert.True(result[1].Array.SequenceEqual(expectMiddle));
             Assert.True(result[2].Array.SequenceEqual(expectEnd));
+
+            var multipleEllipsis = @"
+                var array = [ 1, 2, 3, 4, 5 ];
+                var [ ...head, middle, ...tail ] = array;
+            ";
+
+            Assert.Throws<MondCompilerException>(() => Script.Run(multipleEllipsis));
         }
 
-        [TestCase]
+        [Test]
         public void ObjectDestructuring()
         {
             var result = Script.Run(@"
@@ -70,10 +77,46 @@ namespace Mond.Tests.Expressions
 
             var expectedKeys = new MondValue[] { "foo", "bar", "baz" };
             var expectedValues = new MondValue[] { 1, 2, 3 };
+            var objectEllipsis = @"
+                var object = {
+                    foo: 1,
+                    bar: 2,
+                    baz: 3,
+                };
+
+                var { foo, ...rest } = object;
+            ";
 
             Assert.True(result["keys"].Array.SequenceEqual(expectedKeys));
             Assert.True(result["values"].Array.SequenceEqual(expectedValues));
             Assert.AreEqual(5, (int)result["five"]);
+            Assert.Throws<MondCompilerException>(() => Script.Run(objectEllipsis));
+        }
+
+        [Test]
+        public void MissingDestructuredValue()
+        {
+            var undefinedArray = @"
+                var array = [ 1, 2 ];
+                var [ x, y, z ] = array;
+
+                return x + z;
+            ";
+
+            var undefinedObject = Script.Run(@"
+                var object = {
+                    foo: 'foo',
+                    bar: 'bar',
+                };
+
+                var { foo, bar, baz: x } = object;
+                x = x || 5;
+
+                return foo + x;
+            ");
+
+            Assert.Throws<MondRuntimeException>(() => Script.Run(undefinedArray));
+            Assert.AreEqual(undefinedObject.ToString(), "foo5");
         }
     }
 }

--- a/Mond.Tests/Expressions/DestructuringTests.cs
+++ b/Mond.Tests/Expressions/DestructuringTests.cs
@@ -1,0 +1,79 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace Mond.Tests.Expressions
+{
+    [TestFixture]
+    public class DestructuringTests
+    {
+        [TestCase]
+        public void BasicArrayDestructuring()
+        {
+            var result = Script.Run(@"
+                var array = [ 1, 2, 3, 4, 5 ];      
+                var [ a, b ] = array;
+                var [ y, x ] = array[4:0];
+
+                return [ a, b, x, y ];     
+            ");
+
+            var expected = new MondValue[] { 1, 2, 4, 5 };
+            Assert.True(result.Array.SequenceEqual(expected));
+        }
+
+        [TestCase]
+        public void ArrayEllipsisDestructuring()
+        {
+            var result = Script.Run(@"
+                var array = [ 1, 2, 3, 4, 5 ];
+                var [ ...start, _1 ] = array;
+                var [ _2, ...middle, _3 ] = array;
+                var [ _4, ...end ] = array;
+
+                return [ start, middle, end ];
+            ");
+
+            var expectStart = new MondValue[] { 1, 2, 3, 4 };
+            var expectMiddle = new MondValue[] { 2, 3, 4 };
+            var expectEnd = new MondValue[] { 2, 3, 4, 5 };
+
+            Assert.True(result[0].Array.SequenceEqual(expectStart));
+            Assert.True(result[1].Array.SequenceEqual(expectMiddle));
+            Assert.True(result[2].Array.SequenceEqual(expectEnd));
+        }
+
+        [TestCase]
+        public void ObjectDestructuring()
+        {
+            var result = Script.Run(@"
+                var object = {
+                    foo: 1,
+                    bar: 2,
+                    baz: 3,
+                };
+
+                var { bar: two, baz: three } = object;
+                var keys = [], values = [];
+                
+                foreach (var { key, value } in object)
+                {
+                    keys.add(key);
+                    values.add(value);
+                }
+
+                return {
+                    keys: keys,
+                    values: values,
+                    five: two + three,
+                };
+            ");
+
+            var expectedKeys = new MondValue[] { "foo", "bar", "baz" };
+            var expectedValues = new MondValue[] { 1, 2, 3 };
+
+            Assert.True(result["keys"].Array.SequenceEqual(expectedKeys));
+            Assert.True(result["values"].Array.SequenceEqual(expectedValues));
+            Assert.AreEqual(5, (int)result["five"]);
+        }
+    }
+}

--- a/Mond.Tests/Mond.Tests.csproj
+++ b/Mond.Tests/Mond.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Binding\ModuleTests.cs" />
     <Compile Include="Binding\OperatorTests.cs" />
     <Compile Include="Expressions\ArrayTests.cs" />
+    <Compile Include="Expressions\DestructuringTests.cs" />
     <Compile Include="Expressions\ExpressionTests.cs" />
     <Compile Include="Expressions\FunctionTests.cs" />
     <Compile Include="Expressions\MetamethodTests.cs" />

--- a/Mond/Compiler/CompilerError.cs
+++ b/Mond/Compiler/CompilerError.cs
@@ -27,6 +27,8 @@
         public const string DuplicateCase = "Duplicate case value";
         public const string DuplicateDefault = "Cannot have more than one default case";
 
+        public const string MultipleDestructuringSlices = "Cannot have multiple ellipses in array destructuring";
+
         public const string BadForLoopInitializer = "For loop initializer cannot be statement";
 
         public const string ObjectFunctionNotNamed = "Object literal functions must be named";

--- a/Mond/Compiler/Expressions/Statements/DestructuredArrayExpression.cs
+++ b/Mond/Compiler/Expressions/Statements/DestructuredArrayExpression.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Mond.Compiler.Expressions.Statements
+{
+    class DestructuredArrayExpression : Expression, IStatementExpression
+    {
+        public class Index
+        {
+            public string Name { get; private set; }
+            public bool IsSlice { get; private set; }
+
+            public Index(string name, bool isSlice)
+            {
+                Name = name;
+                IsSlice = isSlice;
+            }
+        }
+
+        public ReadOnlyCollection<Index> Indecies { get; private set; }
+        public Expression Initializer { get; private set; }
+        public bool IsReadOnly { get; private set; }
+        public bool HasChildren { get { return false; } }
+
+        public DestructuredArrayExpression(Token token, IList<Index> indecies, Expression initializer, bool isReadOnly)
+            : base(token)
+        {
+            Indecies = new ReadOnlyCollection<Index>(indecies);
+            Initializer = initializer;
+            IsReadOnly = isReadOnly;
+        }
+
+        public override T Accept<T>(IExpressionVisitor<T> visitor)
+        {
+            return visitor.Visit(this);
+        }
+
+        public override int Compile(FunctionContext context)
+        {
+            context.Position(Token);
+
+            var i = 0;
+            var startIndex = 0;
+            var stack = Initializer == null ? 1 : Initializer.Compile(context);
+            var global = context.ArgIndex == 0 && context.Compiler.Options.MakeRootDeclarationsGlobal;
+
+            foreach (var index in Indecies)
+            {
+                var assign = context.MakeLabel("arrayDestructureAssign");
+                var destruct = context.MakeLabel("arrayDestructureIndex");
+                
+                // var name = array.length() - 1 >= i ? array[i] : undefined;
+                stack += context.Dup();
+                stack += context.Dup();
+                stack += context.LoadField(context.String("length"));
+                stack += context.Call(0, new List<ImmediateOperand>());
+                stack += context.Load(context.Number(1));
+                stack += context.BinaryOperation(TokenType.Subtract);
+                stack += context.Load(context.Number(i));
+                stack += context.BinaryOperation(TokenType.GreaterThanOrEqual);
+
+                stack += context.JumpTrue(destruct);
+                stack += context.Drop();
+                stack += context.LoadUndefined();
+                stack += context.Jump(assign);
+
+                stack += context.Bind(destruct);
+                stack += context.Load(context.Number(startIndex));
+
+                if (index.IsSlice)
+                {
+                    var remaining = Indecies.Skip(i + 1).Count();
+                    startIndex = -remaining;
+
+                    stack += context.Load(context.Number(-remaining - 1));
+                    stack += context.LoadUndefined();
+                    stack += context.Slice();
+                }
+                else
+                {
+                    stack += context.LoadArray();
+                    startIndex++;
+                }
+
+                stack += context.Bind(assign);
+
+                if (global)
+                {
+                    stack += context.LoadGlobal();
+                    stack += context.StoreField(context.String(index.Name));
+                }
+                else
+                {
+                    if (!context.DefineIdentifier(index.Name, IsReadOnly))
+                        throw new MondCompilerException(this, CompilerError.IdentifierAlreadyDefined, index.Name);
+
+                    stack += context.Store(context.Identifier(index.Name));
+                }
+
+                i++;
+            }
+
+            stack += context.Drop();
+            
+            CheckStack(stack, 0);
+            return -1;
+        }
+
+        public override Expression Simplify()
+        {
+            if (Initializer != null)
+                Initializer = Initializer.Simplify();
+
+            return this;
+        }
+    }
+}

--- a/Mond/Compiler/Expressions/Statements/DestructuredObjectExpression.cs
+++ b/Mond/Compiler/Expressions/Statements/DestructuredObjectExpression.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Mond.Compiler.Expressions.Statements
+{
+    class DestructuredObjectExpression : Expression, IStatementExpression
+    {
+        public class Field
+        {
+            public string Name { get; private set; }
+            public string Alias { get; private set; }
+
+            public Field(string name, string alias)
+            {
+                Name = name;
+                Alias = alias;
+            }
+        }
+
+        public ReadOnlyCollection<Field> Fields { get; private set; }
+        public Expression Initializer { get; private set; }
+        public bool IsReadOnly { get; private set; }
+        public bool HasChildren { get { return false; } }
+
+        public DestructuredObjectExpression(Token token, IList<Field> fields, Expression initializer, bool isReadOnly)
+            : base(token)
+        {
+            Fields = new ReadOnlyCollection<Field>(fields);
+            Initializer = initializer;
+            IsReadOnly = isReadOnly;
+        }
+
+        public override T Accept<T>(IExpressionVisitor<T> visitor)
+        {
+            return visitor.Visit(this);
+        }
+
+        public override int Compile(FunctionContext context)
+        {
+            context.Position(Token);
+
+            var stack = Initializer == null ? 1 : Initializer.Compile(context);
+            var global = context.ArgIndex == 0 && context.Compiler.Options.MakeRootDeclarationsGlobal;
+
+            foreach (var field in Fields)
+            {
+                var name = field.Alias ?? field.Name;
+
+                stack += context.Dup();
+                stack += context.LoadField(context.String(field.Name));
+                
+                if (global)
+                {
+                    stack += context.LoadGlobal();
+                    stack += context.StoreField(context.String(name));
+                }
+                else
+                {
+                    if (!context.DefineIdentifier(name, IsReadOnly))
+                        throw new MondCompilerException(this, CompilerError.IdentifierAlreadyDefined, name);
+
+                    stack += context.Store(context.Identifier(name));
+                }
+            }
+
+            stack += context.Drop();
+            
+            CheckStack(stack, 0);
+            return -1;
+        }
+
+        public override Expression Simplify()
+        {
+            if (Initializer != null)
+                Initializer = Initializer.Simplify();
+
+            return this;
+        }
+    }
+}

--- a/Mond/Compiler/Expressions/Statements/ForeachExpression.cs
+++ b/Mond/Compiler/Expressions/Statements/ForeachExpression.cs
@@ -51,11 +51,11 @@ namespace Mond.Compiler.Expressions.Statements
             loopContext.PushScope();
             loopContext.PushLoop(containsFunction.Value ? cont : start, containsFunction.Value ? brk : end);
 
-            var identifier = default(IdentifierOperand);
+            IdentifierOperand identifier;
 
             if (DestructureExpression != null)
             {
-                identifier = context.DefineInternal(Identifier);
+                identifier = context.DefineInternal(Identifier, true);
             }
             else
             {

--- a/Mond/Compiler/Parselets/Statements/ForeachParselet.cs
+++ b/Mond/Compiler/Parselets/Statements/ForeachParselet.cs
@@ -15,7 +15,7 @@ namespace Mond.Compiler.Parselets.Statements
             var varToken = parser.Take(TokenType.Var);
             var inToken = default(Token);
             var destructuring = false;
-            var declaration = default(VarExpression);
+            var declaration = default(Expression);
             var expression = default(Expression);
             var block = default(BlockExpression);
 
@@ -25,7 +25,7 @@ namespace Mond.Compiler.Parselets.Statements
                 inToken = parser.Take(TokenType.In);
 
                 expression = parser.ParseExpression();
-                declaration = VarParselet.DestructureObject(varToken, fields, null, false);
+                declaration = new DestructuredObjectExpression(varToken, fields, null, false);
                 destructuring = true;
             }
 
@@ -35,7 +35,7 @@ namespace Mond.Compiler.Parselets.Statements
                 inToken = parser.Take(TokenType.In);
 
                 expression = parser.ParseExpression();
-                declaration = VarParselet.DestructureArray(varToken, indecies, null, false);
+                declaration = new DestructuredArrayExpression(varToken, indecies, null, false);
                 destructuring = true;
             }
 

--- a/Mond/Compiler/Parselets/Statements/ForeachParselet.cs
+++ b/Mond/Compiler/Parselets/Statements/ForeachParselet.cs
@@ -13,11 +13,10 @@ namespace Mond.Compiler.Parselets.Statements
 
             parser.Take(TokenType.LeftParen);
             var varToken = parser.Take(TokenType.Var);
-            var inToken = default(Token);
-            var destructuring = false;
-            var declaration = default(Expression);
-            var expression = default(Expression);
-            var block = default(BlockExpression);
+            Token inToken;
+            Expression declaration;
+            Expression expression;
+            BlockExpression block;
 
             if (parser.MatchAndTake(TokenType.LeftBrace))
             {
@@ -26,7 +25,11 @@ namespace Mond.Compiler.Parselets.Statements
 
                 expression = parser.ParseExpression();
                 declaration = new DestructuredObjectExpression(varToken, fields, null, false);
-                destructuring = true;
+
+                parser.Take(TokenType.RightParen);
+                block = parser.ParseBlock();
+
+                return new ForeachExpression(token, inToken, "input", expression, block, declaration);
             }
 
             if (parser.MatchAndTake(TokenType.LeftSquare))
@@ -36,12 +39,7 @@ namespace Mond.Compiler.Parselets.Statements
 
                 expression = parser.ParseExpression();
                 declaration = new DestructuredArrayExpression(varToken, indecies, null, false);
-                destructuring = true;
-            }
 
-
-            if (destructuring)
-            {
                 parser.Take(TokenType.RightParen);
                 block = parser.ParseBlock();
 
@@ -50,9 +48,7 @@ namespace Mond.Compiler.Parselets.Statements
 
             var identifier = parser.Take(TokenType.Identifier).Contents;
 
-            inToken = parser.Peek();
-            parser.Take(TokenType.In);
-
+            inToken = parser.Take(TokenType.In);
             expression = parser.ParseExpression();
 
             parser.Take(TokenType.RightParen);

--- a/Mond/Compiler/Parselets/Statements/VarParselet.cs
+++ b/Mond/Compiler/Parselets/Statements/VarParselet.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Mond.Compiler.Expressions;
 using Mond.Compiler.Expressions.Statements;
 
@@ -7,29 +8,29 @@ namespace Mond.Compiler.Parselets.Statements
 {
     class VarParselet : IStatementParselet
     {
-        private class DestructuringField
+        public class DestructuringField
         {
             public Token FieldName { get; private set; }
             public Token AliasName { get; private set; }
 
-            public DestructuringField(Token field, Token alias)
+            internal DestructuringField(Token field, Token alias)
             {
                 FieldName = field;
                 AliasName = alias;
             }
         }
 
-        private class DestructuringIndex
+        public class DestructuringIndex
         {
             public Token Name { get; private set; }
-            public bool Slice { get; private set; }
-            public Expression StartIndex { get; set; }
-            public Expression EndIndex { get; set; }
+            public bool IsSlice { get; private set; }
+            public Expression StartIndex { get; internal set; }
+            public Expression EndIndex { get; internal set; }
 
-            public DestructuringIndex(Token name, bool slice)
+            internal DestructuringIndex(Token name, bool slice)
             {
                 Name = name;
-                Slice = slice;
+                IsSlice = slice;
             }
         }
 
@@ -45,10 +46,20 @@ namespace Mond.Compiler.Parselets.Statements
             trailingSemicolon = true;
 
             if (parser.MatchAndTake(TokenType.LeftBrace))
-                return ParseObjectDestructuring(parser, token);
+            {
+                var fields = ParseObjectDestructuring(parser);
+                parser.Take(TokenType.Assign);
+
+                return DestructureObject(token, fields, parser.ParseExpression(), _isReadOnly);
+            }
 
             if (parser.MatchAndTake(TokenType.LeftSquare))
-                return ParseArrayDestructuring(parser, token);
+            {
+                var indecies = ParseArrayDestructuring(parser);
+                parser.Take(TokenType.Assign);
+
+                return DestructureArray(token, indecies, parser.ParseExpression(), _isReadOnly);
+            }
 
             var declarations = new List<VarExpression.Declaration>();
             do
@@ -69,7 +80,7 @@ namespace Mond.Compiler.Parselets.Statements
             return new VarExpression(token, declarations, _isReadOnly);
         }
 
-        private Expression ParseObjectDestructuring(Parser parser, Token token)
+        internal static ReadOnlyCollection<DestructuringField> ParseObjectDestructuring(Parser parser)
         {
             var fields = new List<DestructuringField>();
             do
@@ -80,22 +91,11 @@ namespace Mond.Compiler.Parselets.Statements
             } while (parser.MatchAndTake(TokenType.Comma));
 
             parser.Take(TokenType.RightBrace);
-            parser.Take(TokenType.Assign);
-            var obj = parser.ParseExpression();
 
-            var declatations = fields.Select(delegate (DestructuringField field)
-            {
-                var initializer = new FieldExpression(field.FieldName, obj);
-                return new VarExpression.Declaration(field.AliasName.Contents, initializer);
-            });
-
-            return new BlockExpression(token, new[]
-            {
-                new VarExpression(token, declatations.ToList(), _isReadOnly)
-            });
+            return fields.AsReadOnly();
         }
 
-        private Expression ParseArrayDestructuring(Parser parser, Token token)
+        internal static ReadOnlyCollection<DestructuringIndex> ParseArrayDestructuring(Parser parser)
         {
             var indecies = new List<DestructuringIndex>();
             var hasEllipsis = false;
@@ -114,37 +114,47 @@ namespace Mond.Compiler.Parselets.Statements
             } while (parser.MatchAndTake(TokenType.Comma));
 
             parser.Take(TokenType.RightSquare);
-            parser.Take(TokenType.Assign);
-            var array = parser.ParseExpression();
 
-            var lengthToken = new Token(token, TokenType.Identifier, "length");
-            var lengthField = new FieldExpression(lengthToken, array);
-            var lengthCall = new CallExpression(lengthToken, lengthField, new List<Expression>());
-            var startIndex = default(Expression);
+            return indecies.AsReadOnly();
+        }
+
+        internal static VarExpression DestructureObject(Token baseToken, IList<DestructuringField> fields, Expression obj, bool isReadOnly)
+        {
+            var declatations = fields.Select(delegate (DestructuringField field)
+             {
+                 var initializer = new FieldExpression(field.FieldName, obj);
+                 return new VarExpression.Declaration(field.AliasName.Contents, initializer);
+             });
+
+            return new VarExpression(baseToken, declatations.ToList(), isReadOnly);
+        }
+
+        internal static VarExpression DestructureArray(Token baseToken, IList<DestructuringIndex> indecies, Expression array, bool isReadOnly)
+        {
+            var arrayToken = array != null ? array.Token : baseToken;
+            var startIndex = default(NumberExpression);
             var declarations = indecies.Select(delegate (DestructuringIndex index, int i)
             {
-                index.StartIndex = startIndex ?? new NumberExpression(array.Token, i);
-                if (index.Slice)
-                {
-                    var subtractToken = new Token(index.StartIndex.Token, TokenType.Subtract, "-");
-                    var subtract = new BinaryOperatorExpression(subtractToken, lengthCall, new NumberExpression(subtractToken, 1));
-                    index.EndIndex = new BinaryOperatorExpression(subtractToken, subtract, index.StartIndex);
-                    startIndex = new BinaryOperatorExpression(subtractToken, lengthCall, index.StartIndex);
-                }
-
+                index.StartIndex = startIndex ?? new NumberExpression(arrayToken, i);
                 var indexer = default(Expression);
-                if (index.Slice)
-                    indexer = new SliceExpression(array.Token, array, index.StartIndex, index.EndIndex, null);
+
+                if (index.IsSlice)
+                {
+                    var remaining = indecies.Skip(i + 1).Count();
+                    index.EndIndex = new NumberExpression(index.StartIndex.Token, -remaining - 1);
+                    startIndex = new NumberExpression(index.StartIndex.Token, -remaining);
+
+                    indexer = new SliceExpression(arrayToken, array, index.StartIndex, index.EndIndex, null);
+                }
                 else
-                    indexer = new IndexerExpression(array.Token, array, index.StartIndex);
+                {
+                    indexer = new IndexerExpression(arrayToken, array, index.StartIndex);
+                }
 
                 return new VarExpression.Declaration(index.Name.Contents, indexer);
             });
 
-            return new BlockExpression(token, new[]
-            {
-                new VarExpression(token, declarations.ToList())
-            });
+            return new VarExpression(baseToken, declarations.ToList());
         }
     }
 }

--- a/Mond/Compiler/Parselets/Statements/VarParselet.cs
+++ b/Mond/Compiler/Parselets/Statements/VarParselet.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Linq;
+using System.Collections.Generic;
 using Mond.Compiler.Expressions;
 using Mond.Compiler.Expressions.Statements;
 
@@ -6,6 +7,32 @@ namespace Mond.Compiler.Parselets.Statements
 {
     class VarParselet : IStatementParselet
     {
+        private class DestructuringField
+        {
+            public Token FieldName { get; private set; }
+            public Token AliasName { get; private set; }
+
+            public DestructuringField(Token field, Token alias)
+            {
+                FieldName = field;
+                AliasName = alias;
+            }
+        }
+
+        private class DestructuringIndex
+        {
+            public Token Name { get; private set; }
+            public bool Slice { get; private set; }
+            public Expression StartIndex { get; set; }
+            public Expression EndIndex { get; set; }
+
+            public DestructuringIndex(Token name, bool slice)
+            {
+                Name = name;
+                Slice = slice;
+            }
+        }
+
         private readonly bool _isReadOnly;
 
         public VarParselet(bool isReadOnly)
@@ -17,8 +44,13 @@ namespace Mond.Compiler.Parselets.Statements
         {
             trailingSemicolon = true;
 
-            var declarations = new List<VarExpression.Declaration>();
+            if (parser.MatchAndTake(TokenType.LeftBrace))
+                return ParseObjectDestructuring(parser, token);
 
+            if (parser.MatchAndTake(TokenType.LeftSquare))
+                return ParseArrayDestructuring(parser, token);
+
+            var declarations = new List<VarExpression.Declaration>();
             do
             {
                 var identifier = parser.Take(TokenType.Identifier);
@@ -35,6 +67,84 @@ namespace Mond.Compiler.Parselets.Statements
             } while (parser.MatchAndTake(TokenType.Comma));
 
             return new VarExpression(token, declarations, _isReadOnly);
+        }
+
+        private Expression ParseObjectDestructuring(Parser parser, Token token)
+        {
+            var fields = new List<DestructuringField>();
+            do
+            {
+                var field = parser.Take(TokenType.Identifier);
+                var name = parser.MatchAndTake(TokenType.Colon) ? parser.Take(TokenType.Identifier) : field;
+                fields.Add(new DestructuringField(field, name));
+            } while (parser.MatchAndTake(TokenType.Comma));
+
+            parser.Take(TokenType.RightBrace);
+            parser.Take(TokenType.Assign);
+            var obj = parser.ParseExpression();
+
+            var declatations = fields.Select(delegate (DestructuringField field)
+            {
+                var initializer = new FieldExpression(field.FieldName, obj);
+                return new VarExpression.Declaration(field.AliasName.Contents, initializer);
+            });
+
+            return new BlockExpression(token, new[]
+            {
+                new VarExpression(token, declatations.ToList(), _isReadOnly)
+            });
+        }
+
+        private Expression ParseArrayDestructuring(Parser parser, Token token)
+        {
+            var indecies = new List<DestructuringIndex>();
+            var hasEllipsis = false;
+            do
+            {
+                var slice = parser.MatchAndTake(TokenType.Ellipsis);
+                var name = parser.Take(TokenType.Identifier);
+
+                if (hasEllipsis && slice)
+                    throw new MondCompilerException(name, CompilerError.MultipleDestructuringSlices);
+
+                if (slice && !hasEllipsis)
+                    hasEllipsis = true;
+
+                indecies.Add(new DestructuringIndex(name, slice));
+            } while (parser.MatchAndTake(TokenType.Comma));
+
+            parser.Take(TokenType.RightSquare);
+            parser.Take(TokenType.Assign);
+            var array = parser.ParseExpression();
+
+            var lengthToken = new Token(token, TokenType.Identifier, "length");
+            var lengthField = new FieldExpression(lengthToken, array);
+            var lengthCall = new CallExpression(lengthToken, lengthField, new List<Expression>());
+            var startIndex = default(Expression);
+            var declarations = indecies.Select(delegate (DestructuringIndex index, int i)
+            {
+                index.StartIndex = startIndex ?? new NumberExpression(array.Token, i);
+                if (index.Slice)
+                {
+                    var subtractToken = new Token(index.StartIndex.Token, TokenType.Subtract, "-");
+                    var subtract = new BinaryOperatorExpression(subtractToken, lengthCall, new NumberExpression(subtractToken, 1));
+                    index.EndIndex = new BinaryOperatorExpression(subtractToken, subtract, index.StartIndex);
+                    startIndex = new BinaryOperatorExpression(subtractToken, lengthCall, index.StartIndex);
+                }
+
+                var indexer = default(Expression);
+                if (index.Slice)
+                    indexer = new SliceExpression(array.Token, array, index.StartIndex, index.EndIndex, null);
+                else
+                    indexer = new IndexerExpression(array.Token, array, index.StartIndex);
+
+                return new VarExpression.Declaration(index.Name.Contents, indexer);
+            });
+
+            return new BlockExpression(token, new[]
+            {
+                new VarExpression(token, declarations.ToList())
+            });
         }
     }
 }

--- a/Mond/Compiler/Visitors/ExpressionPrintVisitor.cs
+++ b/Mond/Compiler/Visitors/ExpressionPrintVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Mond.Compiler.Expressions;
 using Mond.Compiler.Expressions.Statements;
 
@@ -110,7 +111,23 @@ namespace Mond.Compiler.Visitors
 
         public int Visit(ForeachExpression expression)
         {
-            _writer.Write("foreach (var {0} in ", expression.Identifier);
+            _writer.Write("foreach (var ");
+            if (expression.IsDestructuring)
+            {
+                var declarations = expression.DestructureExpression.Declarations;
+                bool isObject = declarations.All(d => d.Initializer is FieldExpression);
+                _writer.Write(isObject ? "{ " : "[ ");
+
+                var names = declarations.Select(d => (d.Initializer is SliceExpression ? "..." : "") + d.Name);
+                _writer.Write(String.Join(", ", names));
+                _writer.Write(isObject ? " }" : " ]");
+            }
+            else
+            {
+                _writer.Write(expression.Identifier);
+            }
+
+            _writer.Write(" in ");
             expression.Expression.Accept(this);
             _writer.WriteLine(")");
 

--- a/Mond/Compiler/Visitors/ExpressionRewriteVisitor.cs
+++ b/Mond/Compiler/Visitors/ExpressionRewriteVisitor.cs
@@ -43,7 +43,8 @@ namespace Mond.Compiler.Visitors
                 expression.InToken,
                 expression.Identifier,
                 expression.Expression.Accept(this),
-                (ScopeExpression)expression.Block.Accept(this))
+                (ScopeExpression)expression.Block.Accept(this),
+                (VarExpression)expression.DestructureExpression.Accept(this))
             {
                 EndToken = expression.EndToken
             };

--- a/Mond/Compiler/Visitors/ExpressionRewriteVisitor.cs
+++ b/Mond/Compiler/Visitors/ExpressionRewriteVisitor.cs
@@ -367,5 +367,23 @@ namespace Mond.Compiler.Visitors
                 EndToken = expression.EndToken
             };
         }
+
+        public virtual Expression Visit(DestructuredObjectExpression expression)
+        {
+            var initializer = expression.Initializer != null ? expression.Initializer.Accept(this) : null;
+            return new DestructuredObjectExpression(expression.Token, expression.Fields, initializer, expression.IsReadOnly)
+            {
+                EndToken = expression.EndToken
+            };
+        }
+
+        public virtual Expression Visit(DestructuredArrayExpression expression)
+        {
+            var initializer = expression.Initializer != null ? expression.Initializer.Accept(this) : null;
+            return new DestructuredArrayExpression(expression.Token, expression.Indecies, initializer, expression.IsReadOnly)
+            {
+                EndToken = expression.EndToken
+            };
+        }
     }
 }

--- a/Mond/Compiler/Visitors/ExpressionVisitor.cs
+++ b/Mond/Compiler/Visitors/ExpressionVisitor.cs
@@ -311,5 +311,21 @@ namespace Mond.Compiler
 
             return default(T);
         }
+
+        public T Visit(DestructuredObjectExpression expression)
+        {
+            if (expression.Initializer != null)
+                expression.Initializer.Accept(this);
+
+            return default(T);
+        }
+
+        public T Visit(DestructuredArrayExpression expression)
+        {
+            if (expression.Initializer != null)
+                expression.Initializer.Accept(this);
+
+            return default(T);
+        }
     }
 }

--- a/Mond/Compiler/Visitors/IExpressionVisitor.cs
+++ b/Mond/Compiler/Visitors/IExpressionVisitor.cs
@@ -44,5 +44,7 @@ namespace Mond.Compiler
         T Visit(UnpackExpression expression);
         T Visit(UserDefinedUnaryOperator expression);
         T Visit(UserDefinedBinaryOperatorExpression expression);
+        T Visit(DestructuredObjectExpression expression);
+        T Visit(DestructuredArrayExpression expression);
     }
 }

--- a/Mond/Mond.csproj
+++ b/Mond/Mond.csproj
@@ -87,6 +87,8 @@
     <Compile Include="Compiler\Expressions\PipelineExpression.cs" />
     <Compile Include="Compiler\Expressions\SliceExpression.cs" />
     <Compile Include="Compiler\Expressions\Statements\DebuggerExpression.cs" />
+    <Compile Include="Compiler\Expressions\Statements\DestructuredArrayExpression.cs" />
+    <Compile Include="Compiler\Expressions\Statements\DestructuredObjectExpression.cs" />
     <Compile Include="Compiler\Expressions\Statements\ForeachExpression.cs" />
     <Compile Include="Compiler\Expressions\Statements\SequenceExpression.cs" />
     <Compile Include="Compiler\Expressions\UserDefinedBinaryOperatorExpression.cs" />

--- a/Mond/MondValue.cs
+++ b/Mond/MondValue.cs
@@ -180,7 +180,10 @@ namespace Mond
                 {
                     var n = (int)index._numberValue;
 
-                    if (n < 0 || n >= ArrayValue.Count)
+                    if (n < 0)
+                        n += ArrayValue.Count;
+
+                    if (n >= ArrayValue.Count)
                         throw new MondRuntimeException(RuntimeError.IndexOutOfBounds);
 
                     return ArrayValue[n];

--- a/Mond/MondValue.cs
+++ b/Mond/MondValue.cs
@@ -183,7 +183,7 @@ namespace Mond
                     if (n < 0)
                         n += ArrayValue.Count;
 
-                    if (n >= ArrayValue.Count)
+                    if (n < 0 || n >= ArrayValue.Count)
                         throw new MondRuntimeException(RuntimeError.IndexOutOfBounds);
 
                     return ArrayValue[n];


### PR DESCRIPTION
This PR aims to implement destructuring assignment in the vein of JavaScript ES2015 with slightly different semantics.

### Semantics

##### Objects

- Fields that don't exist on the destructured object are simply assigned the implementation-defined default value (if any).

``` javascript
var object = { foo: 5 };
var { foo, bar } = object;

printLn( foo ); // => 5
printLn( bar ); // => undefined
```

##### Arrays

- Names are never optional. The following is valid in ES6 but is a syntax error in Mond:

``` javascript
const n = [ 1, 2, 3, 4, 5 ];
const [ , ...middle, ] = n; // The head (1) and tail (5) are unnamed but count towards destructuring such that 'middle' contains the values 2, 3, and 4
```

- Attempting to destructure more fields than an array has items raises an index out of bounds exception. This will probably change and the unused identifiers will just be assigned `undefined`.

``` javascript
var n = [ 1, 2 ];
var [ x, y, z ] = n; // exception
```

- Array destructures are only permitted to have a single ellipsis field (this may change).

``` javascript
var n = [ 1, 2, 3, 4, 5 ];
var [ head, ...middle, tail ] = n; // ok
var [ a, ...b, c, ...d ] = n; // exception
```

-----

At present only basic `var`/`const` declarations support destructuring, but the following functionality is planned:

- [x] object destructuring (`var { foo, bar } = ...`)
- [x] array destructuring (`var [ first, second ] = ...`)
- [x] `var`/`const` declaration destructuring
- [x] `foreach` loop destructuring (`foreach( var { firstName, age } in people ) { ... }`)

I've decided to implement only the very basics as a proof of concept for now pending feedback. As such this PR isn't ready to be merged yet. The implementation is purely syntax sugar for now to avoid over-complicating things at this stage by modifying the VM and compiler with new instructions.

The grammar for destructuring is as follows (in PEG notation)

```
variable = "var" / "const"

fieldAlias   = ':' identifier
objectField  = identifier fieldAlias?
objectFields = objectField ( ',' objectField )*

objectDestruct = variable '{' objectFields '}' = expression ';'

arrayField  = "..." identifier?
arrayFields = arrayField ( ',' arrayField )*

arrayDestruct = variable '[' arrayFields ']' = expression ';'
```

A few trivial examples:

Object:
``` javascript
fun Struct( ...names ) {
    return fun( ...values ) {
        const struct = { };

        for( var i = 0; i < names.length(); ++i ) {
            const value = i >= values.length() ? undefined : values[i];
            const name = names[i];

            struct[name] = value;
        }

        return struct;
    };
}

const Person = Struct( "FirstName", "LastName", "Age" );
const Tony = Person( "Tony", "Ellis", 22 );

const { FirstName: first, LastName: last, Age: age, foo } = Tony;
printLn( first, " ", last, " is ", age, " years old" ); // => Tony Ellis is 22 years old
```

Arrays:
``` javascript
seq ( .. )( lo, hi ) {
    for( var i = lo; i < hi; ++i )
        yield i;
}

fun toArray( lazy ) {
    const a = [ ];
    foreach( var item in lazy )
        a.add( item );

    return a;
}

fun join( arr, delim ) {
    var str = "";
    for( var i = 0; i <= arr.length() - 1; ++i )
        str += arr[i].toString() + delim;
    str += arr[arr.length() - 1];

    return str;
}

const n = ( 1 .. 5 ) |> toArray();
const [ head, ...middle, tail ] = n;

printLn( "head: ", head );                     // => 1
printLn( "middle: ", middle |> join( ", " ) ); // => 2, 3, 4
printLn( "tail: ", tail );                     // => 5
```

A more practical use-case would be importing modules via `require()`.

``` javascript
// seq.mnd
global.export.map = seq( collection, callback ) {
    // ...
};

global.export.filter = seq( collection, predicate ) {
    // ...
};

global.export.aggregate = seq( collection, callback ) {
    // ...
};

// app.mnd
const { map, seq } = require( "./seq.mnd" );

var n = [ 1, 2, 3, 4, 5 ];
map( n, ... );

// versus
const Seq = require( "./seq.mnd" );
Seq.map( n, ... );
```

The options hash pattern when passing arguments to a function would be an ideal use as well.

``` javascript
fun ajax( url, options ) {
    options = options || { };
    var { method, headers, data } = options;
    method = method || "GET";

    var { contentType, contentLength } = headers;

    if( contentType == "application/json" ) {
        data = JSON.stringify( data );
        contentLength = data.length();
    }

    // ...
}

var options = {
    method: "POST",
    contentType: "application/json",
    data: {
        username: "admin",
        password: "admin"
    }
};

var { statusCode, text } = ajax( "https://api.example.com/login", options );
```