### PR TITLE
Expand unicode support in lexer.

### DIFF
--- a/Mond/Compiler/CompilerError.cs
+++ b/Mond/Compiler/CompilerError.cs
@@ -11,7 +11,6 @@
         public const string UnexpectedCharacter = "Unexpected character '{0}'";
         public const string ExpectedButFound = "Expected {0} but found {1}";
         public const string ExpectedButFound2 = "Expected {0} or {1} but found {2}";
-        public const string CrMustBeFollowedByLf = "\\r must be followed by \\n";
 
         public const string IncorrectOperatorArity = "Incorrect operator arity ({0}). User defined operators may only accept 1 (prefix) or 2 (infix) arguments";
         public const string EllipsisInOperator = "User defined operators may not have ellipsis arguments";

--- a/Mond/Compiler/Lexer.Static.cs
+++ b/Mond/Compiler/Lexer.Static.cs
@@ -12,6 +12,7 @@ namespace Mond.Compiler
         private static Dictionary<string, TokenType> _keywords;
         private static HashSet<char> _hexChars;
         private static HashSet<char> _operatorChars;
+        private static HashSet<char> _endOfLineChars;
 
         static Lexer()
         {
@@ -124,6 +125,15 @@ namespace Mond.Compiler
             {
                 '.', '=', '+', '-', '*', '/', '%',
                 '&', '|', '^', '~', '<', '>', '!', '?'
+            };
+
+            _endOfLineChars = new HashSet<char>
+            {
+                '\u000B', // vertical tab (VT)
+                '\u000C', // form feed (FF)
+                '\u0085', // next line (NEL)
+                '\u2028', // line separator (LS)
+                '\u2029', // paragraph separator (PS)
             };
         }
 

--- a/Mond/Compiler/Lexer.cs
+++ b/Mond/Compiler/Lexer.cs
@@ -408,11 +408,7 @@ namespace Mond.Compiler
             // single line comment
             if (TakeIfNext("//"))
             {
-                while (!AtEof && !IsNext("\n"))
-                {
-                    TakeChar();
-                }
-
+                while(!AtEof && TakeChar() != '\n');
                 return true;
             }
 
@@ -504,21 +500,39 @@ namespace Mond.Compiler
 
         public char TakeChar()
         {
-            PeekChar();
-            PeekChar(1);
+            var current = PeekChar();
+            var result = current;
+            if (_endOfLineChars.Contains(current))
+            {
+                _currentLine++;
+                _currentColumn = 0;
+                result = '\n';
+            }
+            else if(current == '\r') // CR and LF have special handling
+            {
+                if (_sourceCode != null)
+                    _sourceCode.Append('\r');
 
-            var result = _read[0];
+                if (PeekChar(1) == '\n')
+                {
+                    if (_sourceCode != null)
+                        _sourceCode.Append('\n');
+
+                    _read.RemoveAt(1);
+                    _index++;
+                }
+
+                result = '\n';
+                _currentLine++;
+                _currentColumn = 0;
+            }
+            else
+            {
+                if (_sourceCode != null && current != '\0')
+                    _sourceCode.Append(current);
+            }
+
             _read.RemoveAt(0);
-
-            if (result == '\r' && _read[0] != '\n')
-                throw new MondCompilerException(_fileName, _currentLine, _currentColumn, CompilerError.CrMustBeFollowedByLf);
-
-            if (result == '\n')
-                AdvanceLine();
-
-            if (_sourceCode != null && result != '\0')
-                _sourceCode.Append(result);
-
             _index++;
             _currentColumn++;
 
@@ -540,12 +554,6 @@ namespace Mond.Compiler
             }
 
             return _read[distance];
-        }
-
-        private void AdvanceLine()
-        {
-            _currentLine++;
-            _currentColumn = 0;
         }
 
         private void MarkPosition()


### PR DESCRIPTION
This change modifies the lexer to accept vertical tab (`U+000B`), form
feed (`U+000C`), next line (`U+0085`), line separator (`U+2028`), and
paragraph separator (`U+2029`) characters as EOL characters, in
addition to CR and LF characters.

The lexer also no longer cares if there's a `\n` after the `\r`, so that one person out there writing Mond on classic Mac OS will no longer get yelled at by the compiler for using CR line endings.

Another important point to note is that when `TakeChar()` consumes any EOL character, it will _always_ return `\n` in it's place, so checking for EOL elsewhere (such as [here](https://github.com/Rohansi/Mond/blob/1b78772625acc23e71845b92ed8429663390ab44/Mond/Compiler/Lexer.cs#L411)) is reliable. `_sourceCode` still receives the proper EOL characters, though.