### PR TITLE
Remove checks to see if the RHS of a binary operator is an object for left-only metamethods.

### DIFF
--- a/Mond.Tests/Expressions/MetamethodTests.cs
+++ b/Mond.Tests/Expressions/MetamethodTests.cs
@@ -220,10 +220,6 @@ namespace Mond.Tests.Expressions
 
             Assert.True((result >> 5) == 5, ">>");
 
-            Assert.True(result.LShift(6) == 6, "LShift");
-
-            Assert.True(result.RShift(7) == 7, "RShift");
-
             Assert.True(~result == 100, "~");
         }
     }

--- a/Mond.Tests/Expressions/MetamethodTests.cs
+++ b/Mond.Tests/Expressions/MetamethodTests.cs
@@ -220,6 +220,10 @@ namespace Mond.Tests.Expressions
 
             Assert.True((result >> 5) == 5, ">>");
 
+            Assert.True(result.LShift(6) == 6, "LShift");
+
+            Assert.True(result.RShift(7) == 7, "RShift");
+
             Assert.True(~result == 100, "~");
         }
     }

--- a/Mond.Tests/MondValueTests.cs
+++ b/Mond.Tests/MondValueTests.cs
@@ -105,15 +105,37 @@ namespace Mond.Tests
         public void OperatorLShift()
         {
             _left = 10.0;
+            _right = 7.0;
+            Assert.AreEqual(_left.LShift(_right), new MondValue(10 << 7));
+
+            _left = 10.0;
             Assert.AreEqual(_left << 7, new MondValue(10 << 7));
+
+            _left = 123;
+            _right = "abc";
+            Assert.Throws<MondRuntimeException>(() => { _left = _left.LShift(_right); });
+
+            _left = "abc";
+            Assert.Throws<MondRuntimeException>(() => { _left = _left.LShift(_right); });
         }
 
         [Test]
         public void OperatorRShift()
         {
+            _left = 10.0;
+            _right = 2.0;
+            Assert.AreEqual(_left.RShift(_right), new MondValue(10 >> 2));
 
             _left = 10.0;
             Assert.AreEqual(_left >> 2, new MondValue(10 >> 2));
+
+            _left = 123;
+            _right = "abc";
+            Assert.Throws<MondRuntimeException>(() => { _left = _left.RShift(_right); });
+
+            _left = "abc";
+            _right = 2.0;
+            Assert.Throws<MondRuntimeException>(() => { _left = _left.RShift(_right); });
         }
 
         [Test]

--- a/Mond.Tests/MondValueTests.cs
+++ b/Mond.Tests/MondValueTests.cs
@@ -105,37 +105,15 @@ namespace Mond.Tests
         public void OperatorLShift()
         {
             _left = 10.0;
-            _right = 7.0;
-            Assert.AreEqual(_left.LShift(_right), new MondValue(10 << 7));
-
-            _left = 10.0;
             Assert.AreEqual(_left << 7, new MondValue(10 << 7));
-
-            _left = 123;
-            _right = "abc";
-            Assert.Throws<MondRuntimeException>(() => { _left = _left.LShift(_right); });
-
-            _left = "abc";
-            Assert.Throws<MondRuntimeException>(() => { _left = _left.LShift(_right); });
         }
 
         [Test]
         public void OperatorRShift()
         {
-            _left = 10.0;
-            _right = 2.0;
-            Assert.AreEqual(_left.RShift(_right), new MondValue(10 >> 2));
 
             _left = 10.0;
             Assert.AreEqual(_left >> 2, new MondValue(10 >> 2));
-
-            _left = 123;
-            _right = "abc";
-            Assert.Throws<MondRuntimeException>(() => { _left = _left.RShift(_right); });
-
-            _left = "abc";
-            _right = 2.0;
-            Assert.Throws<MondRuntimeException>(() => { _left = _left.RShift(_right); });
         }
 
         [Test]

--- a/Mond/MondValue.Operators.cs
+++ b/Mond/MondValue.Operators.cs
@@ -100,133 +100,116 @@ namespace Mond
 
         public static MondValue operator +(MondValue left, MondValue right)
         {
-            if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
-                return new MondValue(left._numberValue + right._numberValue);
-
             if (left.Type == MondValueType.String || right.Type == MondValueType.String)
-            {
-                if (left.TryDispatch("__add", out var result, left, right))
-                    return result;
-
                 return new MondValue(left.ToString() + right.ToString());
-            }
 
-            if (left.Type == MondValueType.Object)
-            {
-                if (left.TryDispatch("__add", out var result, left, right))
-                    return result;
+            if (left.Type == MondValueType.Number)
+                return new MondValue(left._numberValue + (double)right);
 
-                return new MondValue((double)left + (double)right);
-            }
+            if (left.TryDispatch("__add", out var result, left, right))
+                return result;
+
+            if (right.Type == MondValueType.Number)
+                return new MondValue((double)left + right._numberValue);
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "addition", left.Type.GetName(), right.Type.GetName());
         }
 
         public static MondValue operator -(MondValue left, MondValue right)
         {
-            if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
-                return new MondValue(left._numberValue - right._numberValue);
+            if (left.Type == MondValueType.Number)
+                return new MondValue(left._numberValue - (double)right);
 
-            if (left.Type == MondValueType.Object)
-            {
-                if (left.TryDispatch("__sub", out var result, left, right))
-                    return result;
+            if (left.TryDispatch("__sub", out var result, left, right))
+                return result;
 
-                return new MondValue((double)left - (double)right);
-            }
+            if (right.Type == MondValueType.Number)
+                return new MondValue((double)left - right._numberValue);
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "subtraction", left.Type.GetName(), right.Type.GetName());
         }
 
         public static MondValue operator *(MondValue left, MondValue right)
         {
-            if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
-                return new MondValue(left._numberValue * right._numberValue);
+            if (left.Type == MondValueType.Number)
+                return new MondValue(left._numberValue * (double)right);
 
-            if (left.Type == MondValueType.Object)
-            {
-                if (left.TryDispatch("__mul", out var result, left, right))
-                    return result;
+            if (left.TryDispatch("__mul", out var result, left, right))
+                return result;
 
-                return new MondValue((double)left * (double)right);
-            }
+            if (right.Type == MondValueType.Number)
+                return new MondValue((double)left * right._numberValue);
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "multiplication", left.Type.GetName(), right.Type.GetName());
         }
 
         public static MondValue operator /(MondValue left, MondValue right)
         {
-            if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
-                return new MondValue(left._numberValue / right._numberValue);
+            if (left.Type == MondValueType.Number)
+                return new MondValue(left._numberValue / (double)right);
 
-            if (left.Type == MondValueType.Object)
-            {
-                if (left.TryDispatch("__div", out var result, left, right))
-                    return result;
+            if (left.TryDispatch("__div", out var result, left, right))
+                return result;
 
-                return new MondValue((double)left / (double)right);
-            }
+            if (right.Type == MondValueType.Number)
+                return new MondValue((double)left / right._numberValue);
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "division", left.Type.GetName(), right.Type.GetName());
         }
 
         public static MondValue operator %(MondValue left, MondValue right)
         {
-            if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
-                return new MondValue(left._numberValue % right._numberValue);
+            if (left.Type == MondValueType.Number)
+                return new MondValue(left._numberValue % (double)right);
 
-            if (left.Type == MondValueType.Object)
-            {
-                if (left.TryDispatch("__mod", out var result, left, right))
-                    return result;
+            if (left.TryDispatch("__mod", out var result, left, right))
+                return result;
 
-                return new MondValue((double)left % (double)right);
-            }
+            if (right.Type == MondValueType.Number)
+                return new MondValue((double)left % right._numberValue);
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "modulo", left.Type.GetName(), right.Type.GetName());
         }
 
         public MondValue Pow(MondValue right)
         {
-            if (Type == MondValueType.Number && right.Type == MondValueType.Number)
-                return new MondValue(Math.Pow(_numberValue, right._numberValue));
+            if (Type == MondValueType.Number)
+                return new MondValue(Math.Pow(_numberValue, right));
 
-            if (Type == MondValueType.Object)
-            {
-                if (TryDispatch("__pow", out var result, this, right))
-                    return result;
+            if (TryDispatch("__add", out var result, this, right))
+                return result;
 
-                return new MondValue(Math.Pow(this, right));
-            }
+            if (right.Type == MondValueType.Number)
+                return new MondValue(Math.Pow(this, right._numberValue));
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "exponent", Type.GetName(), right.Type.GetName());
         }
 
-        public MondValue LShift(MondValue right)
-        {
-            if (Type == MondValueType.Object)
-            {
-                if (TryDispatch("__lshift", out var result, this, right))
-                    return result;
+        //public MondValue LShift(MondValue right)
+        //{
+        //    if (right.Type == MondValueType.Object)
+        //    {
+        //        if (TryDispatch("__lshift", out var result, this, right))
+        //            return result;
 
-                return new MondValue((int)this << (int)right);
-            }
+        //        return new MondValue((int)this << (int)right);
+        //    }
 
-            return this << (int)right;
-        }
+        //    return this << (int)right;
+        //}
 
-        public MondValue RShift(MondValue right)
-        {
-            if (Type == MondValueType.Object)
-            {
-                if (TryDispatch("__rshift", out var result, this, right))
-                    return result;
+        //public MondValue RShift(MondValue right)
+        //{
+        //    if (Type == MondValueType.Object)
+        //    {
+        //        if (TryDispatch("__rshift", out var result, this, right))
+        //            return result;
 
-                return new MondValue((int)this >> (int)right);
-            }
+        //        return new MondValue((int)this >> (int)right);
+        //    }
 
-            return this >> (int)right;
-        }
+        //    return this >> (int)right;
+        //}
 
         public static MondValue operator <<(MondValue left, int right)
         {
@@ -262,48 +245,42 @@ namespace Mond
 
         public static MondValue operator &(MondValue left, MondValue right)
         {
-            if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
-                return new MondValue((int)left._numberValue & (int)right._numberValue);
+            if (left.Type == MondValueType.Number)
+                return new MondValue((int)left._numberValue & (int)right);
 
-            if (left.Type == MondValueType.Object)
-            {
-                if (left.TryDispatch("__and", out var result, left, right))
-                    return result;
+            if (left.TryDispatch("__and", out var result, left, right))
+                return result;
 
-                return new MondValue((int)left & (int)right);
-            }
+            if (right.Type == MondValueType.Number)
+                return new MondValue((int)left & (int)right._numberValue);
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "bitwise and", left.Type.GetName(), right.Type.GetName());
         }
 
         public static MondValue operator |(MondValue left, MondValue right)
         {
-            if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
-                return new MondValue((int)left._numberValue | (int)right._numberValue);
+            if (left.Type == MondValueType.Number)
+                return new MondValue((int)left._numberValue | (int)right);
 
-            if (left.Type == MondValueType.Object)
-            {
-                if (left.TryDispatch("__or", out var result, left, right))
-                    return result;
+            if (left.TryDispatch("__or", out var result, left, right))
+                return result;
 
-                return new MondValue((int)left | (int)right);
-            }
+            if (right.Type == MondValueType.Number)
+                return new MondValue((int)left | (int)right._numberValue);
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "bitwise or", left.Type.GetName(), right.Type.GetName());
         }
 
         public static MondValue operator ^(MondValue left, MondValue right)
         {
-            if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
-                return new MondValue((int)left._numberValue ^ (int)right._numberValue);
+            if (left.Type == MondValueType.Number)
+                return new MondValue((int)left._numberValue ^ (int)right);
 
-            if (left.Type == MondValueType.Object)
-            {
-                if (left.TryDispatch("__xor", out var result, left, right))
-                    return result;
+            if (left.TryDispatch("__xor", out var result, left, right))
+                return result;
 
-                return new MondValue((int)left ^ (int)right);
-            }
+            if (right.Type == MondValueType.Number)
+                return new MondValue((int)left ^ (int)right._numberValue);
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "bitwise xor", left.Type.GetName(), right.Type.GetName());
         }

--- a/Mond/MondValue.Operators.cs
+++ b/Mond/MondValue.Operators.cs
@@ -176,7 +176,7 @@ namespace Mond
             if (Type == MondValueType.Number)
                 return new MondValue(Math.Pow(_numberValue, right));
 
-            if (TryDispatch("__add", out var result, this, right))
+            if (TryDispatch("__pow", out var result, this, right))
                 return result;
 
             if (right.Type == MondValueType.Number)
@@ -184,32 +184,6 @@ namespace Mond
 
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "exponent", Type.GetName(), right.Type.GetName());
         }
-
-        //public MondValue LShift(MondValue right)
-        //{
-        //    if (right.Type == MondValueType.Object)
-        //    {
-        //        if (TryDispatch("__lshift", out var result, this, right))
-        //            return result;
-
-        //        return new MondValue((int)this << (int)right);
-        //    }
-
-        //    return this << (int)right;
-        //}
-
-        //public MondValue RShift(MondValue right)
-        //{
-        //    if (Type == MondValueType.Object)
-        //    {
-        //        if (TryDispatch("__rshift", out var result, this, right))
-        //            return result;
-
-        //        return new MondValue((int)this >> (int)right);
-        //    }
-
-        //    return this >> (int)right;
-        //}
 
         public static MondValue operator <<(MondValue left, int right)
         {

--- a/Mond/MondValue.Operators.cs
+++ b/Mond/MondValue.Operators.cs
@@ -111,7 +111,7 @@ namespace Mond
                 return new MondValue(left.ToString() + right.ToString());
             }
 
-            if (left.Type == MondValueType.Object || right.Type == MondValueType.Object)
+            if (left.Type == MondValueType.Object)
             {
                 if (left.TryDispatch("__add", out var result, left, right))
                     return result;
@@ -127,7 +127,7 @@ namespace Mond
             if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
                 return new MondValue(left._numberValue - right._numberValue);
 
-            if (left.Type == MondValueType.Object || right.Type == MondValueType.Object)
+            if (left.Type == MondValueType.Object)
             {
                 if (left.TryDispatch("__sub", out var result, left, right))
                     return result;
@@ -143,7 +143,7 @@ namespace Mond
             if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
                 return new MondValue(left._numberValue * right._numberValue);
 
-            if (left.Type == MondValueType.Object || right.Type == MondValueType.Object)
+            if (left.Type == MondValueType.Object)
             {
                 if (left.TryDispatch("__mul", out var result, left, right))
                     return result;
@@ -159,7 +159,7 @@ namespace Mond
             if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
                 return new MondValue(left._numberValue / right._numberValue);
 
-            if (left.Type == MondValueType.Object || right.Type == MondValueType.Object)
+            if (left.Type == MondValueType.Object)
             {
                 if (left.TryDispatch("__div", out var result, left, right))
                     return result;
@@ -175,7 +175,7 @@ namespace Mond
             if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
                 return new MondValue(left._numberValue % right._numberValue);
 
-            if (left.Type == MondValueType.Object || right.Type == MondValueType.Object)
+            if (left.Type == MondValueType.Object)
             {
                 if (left.TryDispatch("__mod", out var result, left, right))
                     return result;
@@ -191,7 +191,7 @@ namespace Mond
             if (Type == MondValueType.Number && right.Type == MondValueType.Number)
                 return new MondValue(Math.Pow(_numberValue, right._numberValue));
 
-            if (Type == MondValueType.Object || right.Type == MondValueType.Object)
+            if (Type == MondValueType.Object)
             {
                 if (TryDispatch("__pow", out var result, this, right))
                     return result;
@@ -204,7 +204,7 @@ namespace Mond
 
         public MondValue LShift(MondValue right)
         {
-            if (Type == MondValueType.Object || right.Type == MondValueType.Object)
+            if (Type == MondValueType.Object)
             {
                 if (TryDispatch("__lshift", out var result, this, right))
                     return result;
@@ -217,7 +217,7 @@ namespace Mond
 
         public MondValue RShift(MondValue right)
         {
-            if (Type == MondValueType.Object || right.Type == MondValueType.Object)
+            if (Type == MondValueType.Object)
             {
                 if (TryDispatch("__rshift", out var result, this, right))
                     return result;
@@ -265,7 +265,7 @@ namespace Mond
             if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
                 return new MondValue((int)left._numberValue & (int)right._numberValue);
 
-            if (left.Type == MondValueType.Object || right.Type == MondValueType.Object)
+            if (left.Type == MondValueType.Object)
             {
                 if (left.TryDispatch("__and", out var result, left, right))
                     return result;
@@ -281,7 +281,7 @@ namespace Mond
             if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
                 return new MondValue((int)left._numberValue | (int)right._numberValue);
 
-            if (left.Type == MondValueType.Object || right.Type == MondValueType.Object)
+            if (left.Type == MondValueType.Object)
             {
                 if (left.TryDispatch("__or", out var result, left, right))
                     return result;
@@ -297,7 +297,7 @@ namespace Mond
             if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
                 return new MondValue((int)left._numberValue ^ (int)right._numberValue);
 
-            if (left.Type == MondValueType.Object || right.Type == MondValueType.Object)
+            if (left.Type == MondValueType.Object)
             {
                 if (left.TryDispatch("__xor", out var result, left, right))
                     return result;

--- a/Mond/MondValue.Operators.cs
+++ b/Mond/MondValue.Operators.cs
@@ -185,6 +185,32 @@ namespace Mond
             throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "exponent", Type.GetName(), right.Type.GetName());
         }
 
+        public MondValue LShift(MondValue right)
+        {
+            if (Type == MondValueType.Object)
+            {
+                if (TryDispatch("__lshift", out var result, this, right))
+                    return result;
+
+                return new MondValue((int)this << (int)right);
+            }
+
+            return this << (int)right;
+        }
+
+        public MondValue RShift(MondValue right)
+        {
+            if (Type == MondValueType.Object)
+            {
+                if (TryDispatch("__rshift", out var result, this, right))
+                    return result;
+
+                return new MondValue((int)this >> (int)right);
+            }
+
+            return this >> (int)right;
+        }
+
         public static MondValue operator <<(MondValue left, int right)
         {
             if (left.Type == MondValueType.Number)

--- a/Mond/VirtualMachine/Machine.cs
+++ b/Mond/VirtualMachine/Machine.cs
@@ -445,7 +445,7 @@ namespace Mond.VirtualMachine
                             {
                                 var right = Pop();
                                 var left = Pop();
-                                Push(left << (int)right);
+                                Push(left.LShift(right));
                                 break;
                             }
 
@@ -453,7 +453,7 @@ namespace Mond.VirtualMachine
                             {
                                 var right = Pop();
                                 var left = Pop();
-                                Push(left >> (int)right);
+                                Push(left.RShift(right));
                                 break;
                             }
 

--- a/Mond/VirtualMachine/Machine.cs
+++ b/Mond/VirtualMachine/Machine.cs
@@ -445,7 +445,7 @@ namespace Mond.VirtualMachine
                             {
                                 var right = Pop();
                                 var left = Pop();
-                                Push(left.LShift(right));
+                                Push(left << (int)right);
                                 break;
                             }
 
@@ -453,7 +453,7 @@ namespace Mond.VirtualMachine
                             {
                                 var right = Pop();
                                 var left = Pop();
-                                Push(left.RShift(right));
+                                Push(left >> (int)right);
                                 break;
                             }
 


### PR DESCRIPTION
Binary operator overloads in `MondValue` no longer check to see if the right-hand side is an object when attempting to dispatch a metamethod since c8f8f63 changes most of them to left-only dispatch.

This wasn't causing any serious bugs, but it was causing weird error messages.

```javascript
var foo = { __sub: () -> undefined };
printLn( "" - foo ); // exception: Cannot cast object to number, __number must be implemented
```

This change results in the correct exception being thrown.

```javascript
var foo = { __sub: () -> undefined };
printLn( "" - foo ); // exception: Cannot use subtraction operator on string and object
```

**edit**: will get those tests squared away soon