### PR TITLE
Update the MondValue indexer setter for arrays to be consistent with the getter.

### DIFF
--- a/Mond/MondValue.cs
+++ b/Mond/MondValue.cs
@@ -216,9 +216,12 @@ namespace Mond
                 if (ReferenceEquals(value, null))
                     throw new ArgumentNullException(nameof(value));
 
-                if (Type == MondValueType.Array && index.Type == MondValueType.Number)
+                if (Type == MondValueType.Array && (index.Type == MondValueType.Number || index.Type == MondValueType.Object))
                 {
-                    var n = (int)index._numberValue;
+                    var n = (int)index;
+
+                    if (n < 0)
+                        n += ArrayValue.Count;
 
                     if (n < 0 || n >= ArrayValue.Count)
                         throw new MondRuntimeException(RuntimeError.IndexOutOfBounds);


### PR DESCRIPTION
This change makes the indexer setter respect negative offsets, as well as objects with the `__number` metamethod as per de48e14.