### PR TITLE
Adds __gte, __lt, and __lte metamethods

### DIFF
--- a/Mond.Tests/Expressions/MetamethodTests.cs
+++ b/Mond.Tests/Expressions/MetamethodTests.cs
@@ -124,7 +124,7 @@ namespace Mond.Tests.Expressions
         [Test]
         public void Relational()
         {
-            // __eq, __gt
+            // __eq, __gt, __gte, __lt, __lte
 
             var result = Script.Run(@"
                 var obj = {
@@ -133,6 +133,15 @@ namespace Mond.Tests.Expressions
                     },
                     __gt: fun (this, value) {
                         return 4 > value;
+                    },
+                    __gte: fun (this, value) {
+                        return 3 >= value;
+                    },
+                    __lt: fun (this, value) {
+                        return value < 6;
+                    },
+                    __lte: fun (this, value ) {
+                        return value <= 5;
                     }
                 };
 
@@ -143,9 +152,9 @@ namespace Mond.Tests.Expressions
 
             Assert.True(result > 3, ">");
 
-            Assert.True(result < 5, "<");
-
             Assert.True(result >= 3, ">=");
+
+            Assert.True(result < 5, "<");
 
             Assert.True(result <= 5, "<=");
         }

--- a/Mond/MondValue.Operators.cs
+++ b/Mond/MondValue.Operators.cs
@@ -361,17 +361,80 @@ namespace Mond
 
         public static bool operator >=(MondValue left, MondValue right)
         {
-            return left > right || left == right;
+            if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
+                return left._numberValue >= right._numberValue;
+
+            if (left.Type == MondValueType.String && right.Type == MondValueType.String)
+                return string.Compare(left._stringValue, right._stringValue, StringComparison.Ordinal) >= 0;
+
+            if (left.Type == MondValueType.Object)
+            {
+                if (left.TryDispatch("__gte", out var result, left, right))
+                    return result;
+            }
+
+            if (right.Type == MondValueType.Object)
+            {
+                if (right.Equals(left))
+                    return false;
+
+                if (right.TryDispatch("__gte", out var result, right, left))
+                    return !result;
+            }
+
+            throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "relational", left.Type.GetName(), right.Type.GetName());
         }
 
         public static bool operator <(MondValue left, MondValue right)
         {
-            return !(left >= right);
+            if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
+                return left._numberValue < right._numberValue;
+
+            if (left.Type == MondValueType.String && right.Type == MondValueType.String)
+                return string.Compare(left._stringValue, right._stringValue, StringComparison.Ordinal) < 0;
+
+            if (left.Type == MondValueType.Object)
+            {
+                if (left.TryDispatch("__lt", out var result, left, right))
+                    return result;
+            }
+
+            if (right.Type == MondValueType.Object)
+            {
+                if (right.Equals(left))
+                    return false;
+
+                if (right.TryDispatch("__lt", out var result, right, left))
+                    return !result;
+            }
+
+            throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "relational", left.Type.GetName(), right.Type.GetName());
         }
 
         public static bool operator <=(MondValue left, MondValue right)
         {
-            return !(left > right);
+            if (left.Type == MondValueType.Number && right.Type == MondValueType.Number)
+                return left._numberValue <= right._numberValue;
+
+            if (left.Type == MondValueType.String && right.Type == MondValueType.String)
+                return string.Compare(left._stringValue, right._stringValue, StringComparison.Ordinal) <= 0;
+
+            if (left.Type == MondValueType.Object)
+            {
+                if (left.TryDispatch("__lte", out var result, left, right))
+                    return result;
+            }
+
+            if (right.Type == MondValueType.Object)
+            {
+                if (right.Equals(left))
+                    return false;
+
+                if (right.TryDispatch("__lte", out var result, right, left))
+                    return !result;
+            }
+
+            throw new MondRuntimeException(RuntimeError.CantUseOperatorOnTypes, "relational", left.Type.GetName(), right.Type.GetName());
         }
     }
 }


### PR DESCRIPTION
Implementing #61. `__eq` wasn't given a twin because having different behaviour for `==` and `!=` seems like it would be pointless.