### PR TITLE
Implement infix backtick functions.

### DIFF
--- a/Mond.Tests/Expressions/FunctionTests.cs
+++ b/Mond.Tests/Expressions/FunctionTests.cs
@@ -419,5 +419,42 @@ namespace Mond.Tests.Expressions
             Assert.AreEqual(MondValueType.String, result.Type);
             Assert.True(result == "Outer.inner");
         }
+
+        [Test]
+        public void BacktickInfixFunction()
+        {
+            // test basic functionality
+            var result = Script.Run(@"
+                fun like(a, b) -> a.toLower() == b.toLower();
+
+                return 'FOO' `like` 'foo';
+            ");
+
+            Assert.True(result);
+
+            // test chaining
+            result = Script.Run(@"
+                seq to(begin, end) {
+                    for (var i = begin; i <= end; ++i)
+                        yield i;
+                }
+
+                fun fold(enumerable, fn) {
+                    const enumerator = enumerable.getEnumerator();
+                    enumerator.moveNext();
+
+                    var accumulator = enumerator.current;
+                    while (enumerator.moveNext())
+                        accumulator = fn( accumulator, enumerator.current );
+
+                    enumerator.dispose();
+                    return accumulator;
+                }
+
+                return 1 `to` 5 `fold` (+);
+            ");
+
+            Assert.AreEqual((MondValue)15, result);
+        }
     }
 }

--- a/Mond/Compiler/Parselets/BacktickParselet.cs
+++ b/Mond/Compiler/Parselets/BacktickParselet.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Mond.Compiler.Expressions;
+
+namespace Mond.Compiler.Parselets
+{
+    class BacktickParselet : IInfixParselet
+    {
+        public int Precedence => (int)PrecedenceValue.Relational; // same as UDOs
+
+        public Expression Parse(Parser parser, Expression left, Token token)
+        {
+            var right = parser.ParseExpression(Precedence);
+            var ident = new Token(token, TokenType.Identifier, token.Contents);
+            var method = new IdentifierExpression(ident);
+            return new CallExpression(token, method, new List<Expression> { left, right });
+        }
+    }
+}

--- a/Mond/Compiler/Parser.Static.cs
+++ b/Mond/Compiler/Parser.Static.cs
@@ -59,8 +59,9 @@ namespace Mond.Compiler
             RegisterInfix(TokenType.In, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
             RegisterInfix(TokenType.NotIn, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
 
-            // UDO stuff. We need to add all these so UDOs can parse correctly
+            // custom infix/prefix stuff
             RegisterInfix(TokenType.UserDefinedOperator, new BinaryOperatorParselet((int)PrecedenceValue.Relational, false));
+            RegisterInfix(TokenType.BacktickIdentifier, new BacktickParselet());
             RegisterPrefix(TokenType.UserDefinedOperator, new PrefixOperatorParselet((int)PrecedenceValue.Prefix));
 
             // prefix inc/decrement

--- a/Mond/Compiler/Token.cs
+++ b/Mond/Compiler/Token.cs
@@ -11,6 +11,7 @@
     enum TokenType
     {
         Identifier,
+        BacktickIdentifier,
         Number,
         String,
 

--- a/Mond/Libraries/Core/Operators.cs
+++ b/Mond/Libraries/Core/Operators.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Mond.Binding;
+﻿using Mond.Binding;
 
 namespace Mond.Libraries.Core
 {


### PR DESCRIPTION
This implements backtick quoted identifiers to be used as infix operators, inspired by the mention of backtick operators in #65, the intent is they will complement UDOs by allowing regular functions to be used as infix operators since a UDO can't be defined as `fun ( ident )( x, y ) { ... }`.

Backtick identifiers are only valid in an infix context, as it made little sense to me to also have them as prefix operators when they could just as easily have been called normally instead.

Examples (pulled from the new test cases):

```javascript
fun like(a, b) -> a.toLower() == b.toLower();

return "FOO" `like` "foo"; // true
```

```javascript
seq to(begin, end) {
    for (var i = begin; i <= end; ++i)
        yield i;
}

fun fold(enumerable, fn) {
    const enumerator = enumerable.getEnumerator();
    enumerator.moveNext();

    var accumulator = enumerator.current;
    while (enumerator.moveNext())
        accumulator = fn( accumulator, enumerator.current );

    enumerator.dispose();
    return accumulator;
}

return 1 `to` 5 `fold` (+); // 15
```