### PR TITLE
VM tweak to allow large hard-coded arrays.

### DIFF
--- a/Mond/Compiler/Expressions/ArrayExpression.cs
+++ b/Mond/Compiler/Expressions/ArrayExpression.cs
@@ -35,14 +35,14 @@ namespace Mond.Compiler.Expressions
                 stack += context.NewArray(FlushSize);
 
                 var i = FlushSize;
-                while( i < Values.Count )
+                while (i < Values.Count)
                 {
-                    var remaining = Math.Min( FlushSize, Values.Count - i );
+                    var remaining = Math.Min(FlushSize, Values.Count - i);
 
-                    for( var j = i; j < i + remaining; ++j )
-                        stack += Values[j].Compile( context );
+                    for (var j = i; j < i + remaining; ++j)
+                        stack += Values[j].Compile(context);
 
-                    stack += context.FlushArray( remaining );
+                    stack += context.FlushArray(remaining);
                     i += remaining;
                 }
             }

--- a/Mond/Compiler/FunctionContext.Helper.cs
+++ b/Mond/Compiler/FunctionContext.Helper.cs
@@ -165,19 +165,13 @@ namespace Mond.Compiler
         public int NewArray(int length)
         {
             Emit(new Instruction(InstructionType.NewArray, new ImmediateOperand(length)));
-            return -length + 1;
+            return 1;
         }
 
         public int Slice()
         {
             Emit(new Instruction(InstructionType.Slice));
             return -4 + 1;
-        }
-
-        public int FlushArray(int length)
-        {
-            Emit(new Instruction(InstructionType.FlushArr, new ImmediateOperand(length)));
-            return -length;
         }
 
         public int Dup()

--- a/Mond/Compiler/FunctionContext.Helper.cs
+++ b/Mond/Compiler/FunctionContext.Helper.cs
@@ -174,6 +174,12 @@ namespace Mond.Compiler
             return -4 + 1;
         }
 
+        public int FlushArray(int length)
+        {
+            Emit(new Instruction(InstructionType.FlushArr, new ImmediateOperand(length)));
+            return -length;
+        }
+
         public int Dup()
         {
             Emit(new Instruction(InstructionType.Dup));

--- a/Mond/Compiler/Instruction.cs
+++ b/Mond/Compiler/Instruction.cs
@@ -21,6 +21,7 @@ namespace Mond.Compiler
         LdState, StState,                   // load/store current frame stack and evals in another frame
 
         NewObject, NewArray,                // create object/array
+        FlushArr,                           // flush the stack to the current array
         Slice,                              // slice array
 
         Add, Sub, Mul, Div, Mod, Exp,       // math

--- a/Mond/Compiler/Instruction.cs
+++ b/Mond/Compiler/Instruction.cs
@@ -21,7 +21,6 @@ namespace Mond.Compiler
         LdState, StState,                   // load/store current frame stack and evals in another frame
 
         NewObject, NewArray,                // create object/array
-        FlushArr,                           // flush the stack to the current array
         Slice,                              // slice array
 
         Add, Sub, Mul, Div, Mod, Exp,       // math

--- a/Mond/MondProgram.cs
+++ b/Mond/MondProgram.cs
@@ -12,7 +12,7 @@ namespace Mond
     public sealed class MondProgram
     {
         private const uint MagicId = 0xFA57C0DE;
-        private const byte FormatVersion = 6;
+        private const byte FormatVersion = 7;
 
         internal readonly byte[] Bytecode;
         internal readonly List<MondValue> Numbers;

--- a/Mond/MondProgram.cs
+++ b/Mond/MondProgram.cs
@@ -12,7 +12,7 @@ namespace Mond
     public sealed class MondProgram
     {
         private const uint MagicId = 0xFA57C0DE;
-        private const byte FormatVersion = 7;
+        private const byte FormatVersion = 6;
 
         internal readonly byte[] Bytecode;
         internal readonly List<MondValue> Numbers;

--- a/Mond/VirtualMachine/Machine.cs
+++ b/Mond/VirtualMachine/Machine.cs
@@ -364,16 +364,10 @@ namespace Mond.VirtualMachine
                             {
                                 var count = ReadInt32(code, ref ip);
                                 var array = new MondValue(MondValueType.Array);
+                                array.ArrayValue.Capacity = count;
 
                                 for (var i = 0; i < count; i++)
-                                {
                                     array.ArrayValue.Add(default(MondValue));
-                                }
-
-                                for (var i = count - 1; i >= 0; i--)
-                                {
-                                    array.ArrayValue[i] = Pop();
-                                }
 
                                 Push(array);
                                 break;
@@ -387,19 +381,6 @@ namespace Mond.VirtualMachine
                                 var array = Pop();
 
                                 Push(array.Slice(start, end, step));
-                                break;
-                            }
-
-                        case (int)InstructionType.FlushArr:
-                            {
-                                var remaining = ReadInt32(code, ref ip);
-                                var buf = new MondValue[remaining];
-
-                                for (var i = remaining - 1; i >= 0; i--)
-                                    buf[i] = Pop();
-
-                                Peek().ArrayValue.AddRange(buf);
-
                                 break;
                             }
                         #endregion

--- a/Mond/VirtualMachine/Machine.cs
+++ b/Mond/VirtualMachine/Machine.cs
@@ -389,6 +389,19 @@ namespace Mond.VirtualMachine
                                 Push(array.Slice(start, end, step));
                                 break;
                             }
+
+                        case (int)InstructionType.FlushArr:
+                            {
+                                var remaining = ReadInt32(code, ref ip);
+                                var buf = new MondValue[remaining];
+
+                                for (var i = remaining - 1; i >= 0; i--)
+                                    buf[i] = Pop();
+
+                                Peek().ArrayValue.AddRange(buf);
+
+                                break;
+                            }
                         #endregion
 
                         #region Math


### PR DESCRIPTION
As it is, the VM will try to push all elements of a hard-coded array to the stack ahead of the `NewArray` instruction, which causes stack overflow exceptions if the array has ≥250 elements at most, which is a problem when hard-coding a lookup table for e.g. CRC-16-CCITT.

~~This change modifies the compiler to insert a new `FlushArr` instruction after every 32 elements (if the array is has more than 32 elements) to avoid overflows. This can be easily adjusted by changing this line:~~

**Edit**: I've realized it's both simpler and more sensible to just initialize arrays the same way objects are created. It solves the problem and minimizes the stack space required to create arbitrarily large arrays. Implementation has been changed accordingly. No new instructions needed.