### PR TITLE
Fix a parse exception related to require()-ing modules.

### DIFF
--- a/Mond/Libraries/Core/Require.cs
+++ b/Mond/Libraries/Core/Require.cs
@@ -81,7 +81,7 @@ namespace Mond.Libraries.Core
                 var moduleSource = _require.Loader(resovledName);
 
                 // wrap the module script in a function so we can pass out exports object to it
-                var source = _require.Definitions + "return fun (exports) {\n" + moduleSource + " return exports; };";
+                var source = _require.Definitions + "return fun (exports) {\n" + moduleSource + "\n return exports; };";
 
                 var options = new MondCompilerOptions
                 {


### PR DESCRIPTION
When attempting to load a module with `require()`, if the last line of the module to be loaded was a line comment, it would result in malformed code generated in the `Require` library that couldn't be parsed properly.

Fixes #92